### PR TITLE
Rename method of computing loss

### DIFF
--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -192,7 +192,7 @@ class FDICAbase:
         return output
 
     def compute_loss(self) -> float:
-        r"""Compute negative log-likelihood :math:`\mathcal{L}`.
+        r"""Compute loss :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
 
@@ -207,7 +207,7 @@ class FDICAbase:
 
         Returns:
             float:
-                Computed negative log-likelihood.
+                Computed loss.
         """
         X, W = self.input, self.demix_filter
         Y = self.separate(X, demix_filter=W)  # (n_sources, n_bins, n_frames)

--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -191,7 +191,7 @@ class FDICAbase:
 
         return output
 
-    def compute_negative_loglikelihood(self) -> float:
+    def compute_loss(self) -> float:
         r"""Compute negative log-likelihood :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
@@ -370,7 +370,7 @@ class GradFDICAbase(FDICAbase):
         self._reset(**kwargs)
 
         if self.should_record_loss:
-            loss = self.compute_negative_loglikelihood()
+            loss = self.compute_loss()
             self.loss.append(loss)
 
         if self.callbacks is not None:
@@ -381,7 +381,7 @@ class GradFDICAbase(FDICAbase):
             self.update_once()
 
             if self.should_record_loss:
-                loss = self.compute_negative_loglikelihood()
+                loss = self.compute_loss()
                 self.loss.append(loss)
 
             if self.callbacks is not None:
@@ -860,7 +860,7 @@ class AuxFDICA(FDICAbase):
         self._reset(**kwargs)
 
         if self.should_record_loss:
-            loss = self.compute_negative_loglikelihood()
+            loss = self.compute_loss()
             self.loss.append(loss)
 
         if self.callbacks is not None:
@@ -871,7 +871,7 @@ class AuxFDICA(FDICAbase):
             self.update_once()
 
             if self.should_record_loss:
-                loss = self.compute_negative_loglikelihood()
+                loss = self.compute_loss()
                 self.loss.append(loss)
 
             if self.callbacks is not None:

--- a/ssspy/bss/ica.py
+++ b/ssspy/bss/ica.py
@@ -175,7 +175,7 @@ class GradICAbase:
         return output
 
     def compute_loss(self) -> float:
-        r"""Compute negative log-likelihood :math:`\mathcal{L}`.
+        r"""Compute loss :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
 
@@ -188,7 +188,7 @@ class GradICAbase:
 
         Returns:
             float:
-                Computed negative log-likelihood.
+                Computed loss.
         """
         X, W = self.input, self.demix_filter
         Y = self.separate(X, demix_filter=W)  # (n_channels, n_samples)
@@ -421,7 +421,7 @@ class FastICAbase:
         return output
 
     def compute_loss(self) -> float:
-        r"""Compute negative log-likelihood :math:`\mathcal{L}`.
+        r"""Compute loss :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
 
@@ -433,7 +433,7 @@ class FastICAbase:
 
         Returns:
             float:
-                Computed negative log-likelihood.
+                Computed loss.
         """
         Z, W = self.whitened_input, self.demix_filter
         Y = self.separate(Z, demix_filter=W, should_whiten=False)
@@ -925,7 +925,7 @@ class GradLaplaceICA(GradICA):
         super().update_once()
 
     def compute_loss(self) -> float:
-        r"""Compute negative log-likelihood :math:`\mathcal{L}`.
+        r"""Compute loss :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
 
@@ -936,7 +936,7 @@ class GradLaplaceICA(GradICA):
 
         Returns:
             float:
-                Computed negative log-likelihood.
+                Computed loss.
         """
         return super().compute_loss()
 
@@ -1041,7 +1041,7 @@ class NaturalGradLaplaceICA(NaturalGradICA):
         super().update_once()
 
     def compute_loss(self) -> float:
-        r"""Compute negative log-likelihood :math:`\mathcal{L}`.
+        r"""Compute loss :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
 
@@ -1052,6 +1052,6 @@ class NaturalGradLaplaceICA(NaturalGradICA):
 
         Returns:
             float:
-                Computed negative log-likelihood.
+                Computed loss.
         """
         return super().compute_loss()

--- a/ssspy/bss/ica.py
+++ b/ssspy/bss/ica.py
@@ -86,7 +86,7 @@ class GradICAbase:
         self._reset(**kwargs)
 
         if self.should_record_loss:
-            loss = self.compute_negative_loglikelihood()
+            loss = self.compute_loss()
             self.loss.append(loss)
 
         if self.callbacks is not None:
@@ -97,7 +97,7 @@ class GradICAbase:
             self.update_once()
 
             if self.should_record_loss:
-                loss = self.compute_negative_loglikelihood()
+                loss = self.compute_loss()
                 self.loss.append(loss)
 
             if self.callbacks is not None:
@@ -174,7 +174,7 @@ class GradICAbase:
 
         return output
 
-    def compute_negative_loglikelihood(self) -> float:
+    def compute_loss(self) -> float:
         r"""Compute negative log-likelihood :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
@@ -284,7 +284,7 @@ class FastICAbase:
         self._reset(**kwargs)
 
         if self.should_record_loss:
-            loss = self.compute_negative_loglikelihood()
+            loss = self.compute_loss()
             self.loss.append(loss)
 
         if self.callbacks is not None:
@@ -295,7 +295,7 @@ class FastICAbase:
             self.update_once()
 
             if self.should_record_loss:
-                loss = self.compute_negative_loglikelihood()
+                loss = self.compute_loss()
                 self.loss.append(loss)
 
             if self.callbacks is not None:
@@ -420,7 +420,7 @@ class FastICAbase:
 
         return output
 
-    def compute_negative_loglikelihood(self) -> float:
+    def compute_loss(self) -> float:
         r"""Compute negative log-likelihood :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
@@ -924,7 +924,7 @@ class GradLaplaceICA(GradICA):
         """
         super().update_once()
 
-    def compute_negative_loglikelihood(self) -> float:
+    def compute_loss(self) -> float:
         r"""Compute negative log-likelihood :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
@@ -938,7 +938,7 @@ class GradLaplaceICA(GradICA):
             float:
                 Computed negative log-likelihood.
         """
-        return super().compute_negative_loglikelihood()
+        return super().compute_loss()
 
 
 class NaturalGradLaplaceICA(NaturalGradICA):
@@ -1040,7 +1040,7 @@ class NaturalGradLaplaceICA(NaturalGradICA):
         """
         super().update_once()
 
-    def compute_negative_loglikelihood(self) -> float:
+    def compute_loss(self) -> float:
         r"""Compute negative log-likelihood :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
@@ -1054,4 +1054,4 @@ class NaturalGradLaplaceICA(NaturalGradICA):
             float:
                 Computed negative log-likelihood.
         """
-        return super().compute_negative_loglikelihood()
+        return super().compute_loss()

--- a/ssspy/bss/iva.py
+++ b/ssspy/bss/iva.py
@@ -184,7 +184,7 @@ class IVAbase:
         """
         raise NotImplementedError("Implement 'update_once' method.")
 
-    def compute_negative_loglikelihood(self) -> float:
+    def compute_loss(self) -> float:
         r"""Compute negative log-likelihood :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
@@ -321,7 +321,7 @@ class GradIVAbase(IVAbase):
         self._reset(**kwargs)
 
         if self.should_record_loss:
-            loss = self.compute_negative_loglikelihood()
+            loss = self.compute_loss()
             self.loss.append(loss)
 
         if self.callbacks is not None:
@@ -332,7 +332,7 @@ class GradIVAbase(IVAbase):
             self.update_once()
 
             if self.should_record_loss:
-                loss = self.compute_negative_loglikelihood()
+                loss = self.compute_loss()
                 self.loss.append(loss)
 
             if self.callbacks is not None:
@@ -834,7 +834,7 @@ class AuxIVA(AuxIVAbase):
         self._reset(**kwargs)
 
         if self.should_record_loss:
-            loss = self.compute_negative_loglikelihood()
+            loss = self.compute_loss()
             self.loss.append(loss)
 
         if self.callbacks is not None:
@@ -845,7 +845,7 @@ class AuxIVA(AuxIVAbase):
             self.update_once()
 
             if self.should_record_loss:
-                loss = self.compute_negative_loglikelihood()
+                loss = self.compute_loss()
                 self.loss.append(loss)
 
             if self.callbacks is not None:
@@ -1246,9 +1246,9 @@ class AuxIVA(AuxIVAbase):
 
         self.output = Y
 
-    def compute_negative_loglikelihood(self) -> float:
+    def compute_loss(self) -> float:
         if self.algorithm_spatial in ["IP", "IP1", "IP2"]:
-            return super().compute_negative_loglikelihood()
+            return super().compute_loss()
         else:
             X, Y = self.input, self.output
             G = self.contrast_fn(Y)  # (n_sources, n_frames)
@@ -1409,7 +1409,7 @@ class GradLaplaceIVA(GradIVA):
         """
         return super().update_once()
 
-    def compute_negative_loglikelihood(self) -> float:
+    def compute_loss(self) -> float:
         r"""Compute negative log-likelihood :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
@@ -1423,7 +1423,7 @@ class GradLaplaceIVA(GradIVA):
             float:
                 Computed negative log-likelihood.
         """
-        return super().compute_negative_loglikelihood()
+        return super().compute_loss()
 
 
 class NaturalGradLaplaceIVA(NaturalGradIVA):
@@ -1564,7 +1564,7 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
         """
         return super().update_once()
 
-    def compute_negative_loglikelihood(self) -> float:
+    def compute_loss(self) -> float:
         r"""Compute negative log-likelihood :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
@@ -1578,7 +1578,7 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
             float:
                 Computed negative log-likelihood.
         """
-        return super().compute_negative_loglikelihood()
+        return super().compute_loss()
 
 
 class AuxLaplaceIVA(AuxIVA):

--- a/ssspy/bss/iva.py
+++ b/ssspy/bss/iva.py
@@ -185,7 +185,7 @@ class IVAbase:
         raise NotImplementedError("Implement 'update_once' method.")
 
     def compute_loss(self) -> float:
-        r"""Compute negative log-likelihood :math:`\mathcal{L}`.
+        r"""Compute loss :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
 
@@ -198,7 +198,7 @@ class IVAbase:
 
         Returns:
             float:
-                Computed negative log-likelihood.
+                Computed loss.
         """
         X, W = self.input, self.demix_filter
         Y = self.separate(X, demix_filter=W)  # (n_sources, n_bins, n_frames)
@@ -1410,7 +1410,7 @@ class GradLaplaceIVA(GradIVA):
         return super().update_once()
 
     def compute_loss(self) -> float:
-        r"""Compute negative log-likelihood :math:`\mathcal{L}`.
+        r"""Compute loss :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
 
@@ -1421,7 +1421,7 @@ class GradLaplaceIVA(GradIVA):
 
         Returns:
             float:
-                Computed negative log-likelihood.
+                Computed loss.
         """
         return super().compute_loss()
 
@@ -1565,7 +1565,7 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
         return super().update_once()
 
     def compute_loss(self) -> float:
-        r"""Compute negative log-likelihood :math:`\mathcal{L}`.
+        r"""Compute loss :math:`\mathcal{L}`.
 
         :math:`\mathcal{L}` is given as follows:
 
@@ -1576,7 +1576,7 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
 
         Returns:
             float:
-                Computed negative log-likelihood.
+                Computed loss.
         """
         return super().compute_loss()
 


### PR DESCRIPTION
## Summary
Rename `compute_negative_loglikelihood` to `compute_loss` since the returned value is computed by averaging negative log-likelihood over time frames.

close #26 