### PR TITLE
Reset demixing filter

### DIFF
--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -160,8 +160,11 @@ class FDICAbase:
             W = np.eye(n_sources, n_channels, dtype=np.complex128)
             W = np.tile(W, reps=(n_bins, 1, 1))
         else:
-            # To avoid overwriting ``demix_filter`` given by keyword arguments.
-            W = self.demix_filter.copy()
+            if self.demix_filter is None:
+                W = self.demix_filter
+            else:
+                # To avoid overwriting ``demix_filter`` given by keyword arguments.
+                W = self.demix_filter.copy()
 
         self.demix_filter = W
         self.output = self.separate(X, demix_filter=W)

--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -161,7 +161,7 @@ class FDICAbase:
             W = np.tile(W, reps=(n_bins, 1, 1))
         else:
             if self.demix_filter is None:
-                W = self.demix_filter
+                W = None
             else:
                 # To avoid overwriting ``demix_filter`` given by keyword arguments.
                 W = self.demix_filter.copy()

--- a/ssspy/bss/ica.py
+++ b/ssspy/bss/ica.py
@@ -139,8 +139,11 @@ class GradICAbase:
         if not hasattr(self, "demix_filter"):
             W = np.eye(n_sources, n_channels, dtype=np.float64)
         else:
-            # To avoid overwriting ``demix_filter`` given by keyword arguments.
-            W = self.demix_filter.copy()
+            if self.demix_filter is None:
+                W = self.demix_filter
+            else:
+                # To avoid overwriting ``demix_filter`` given by keyword arguments.
+                W = self.demix_filter.copy()
 
         self.demix_filter = W
         self.output = self.separate(X, demix_filter=W)
@@ -338,8 +341,11 @@ class FastICAbase:
         if not hasattr(self, "demix_filter"):
             W = np.eye(n_sources, n_channels, dtype=np.float64)
         else:
-            # To avoid overwriting ``demix_filter`` given by keyword arguments.
-            W = self.demix_filter.copy()
+            if self.demix_filter is None:
+                W = self.demix_filter
+            else:
+                # To avoid overwriting ``demix_filter`` given by keyword arguments.
+                W = self.demix_filter.copy()
 
         XX_trans = np.mean(X[:, np.newaxis, :] * X[np.newaxis, :, :], axis=-1)
         lamb, Gamma = np.linalg.eigh(XX_trans)  # (n_channels,), (n_channels, n_channels)

--- a/ssspy/bss/ica.py
+++ b/ssspy/bss/ica.py
@@ -140,7 +140,7 @@ class GradICAbase:
             W = np.eye(n_sources, n_channels, dtype=np.float64)
         else:
             if self.demix_filter is None:
-                W = self.demix_filter
+                W = None
             else:
                 # To avoid overwriting ``demix_filter`` given by keyword arguments.
                 W = self.demix_filter.copy()
@@ -342,7 +342,7 @@ class FastICAbase:
             W = np.eye(n_sources, n_channels, dtype=np.float64)
         else:
             if self.demix_filter is None:
-                W = self.demix_filter
+                W = None
             else:
                 # To avoid overwriting ``demix_filter`` given by keyword arguments.
                 W = self.demix_filter.copy()

--- a/ssspy/bss/iva.py
+++ b/ssspy/bss/iva.py
@@ -148,7 +148,7 @@ class IVAbase:
             W = np.tile(W, reps=(n_bins, 1, 1))
         else:
             if self.demix_filter is None:
-                W = self.demix_filter
+                W = None
             else:
                 # To avoid overwriting ``demix_filter`` given by keyword arguments.
                 W = self.demix_filter.copy()

--- a/ssspy/bss/iva.py
+++ b/ssspy/bss/iva.py
@@ -147,8 +147,11 @@ class IVAbase:
             W = np.eye(n_sources, n_channels, dtype=np.complex128)
             W = np.tile(W, reps=(n_bins, 1, 1))
         else:
-            # To avoid overwriting ``demix_filter`` given by keyword arguments.
-            W = self.demix_filter.copy()
+            if self.demix_filter is None:
+                W = self.demix_filter
+            else:
+                # To avoid overwriting ``demix_filter`` given by keyword arguments.
+                W = self.demix_filter.copy()
 
         self.demix_filter = W
         self.output = self.separate(X, demix_filter=W)

--- a/tests/bss/test_fdica.py
+++ b/tests/bss/test_fdica.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Callable, List
+from typing import Optional, Union, Callable, List, Dict, Any
 
 import pytest
 import numpy as np
@@ -15,6 +15,8 @@ from ssspy.bss.fdica import (
 from ssspy.utils.dataset import download_dummy_data
 
 max_samples = 16000
+n_fft = 2048
+n_bins = n_fft // 2 + 1
 n_iter = 5
 
 
@@ -31,22 +33,33 @@ class DummyCallback:
 
 
 parameters_grad_fdica = [
-    (2, None, True),
-    (3, dummy_function, False),
-    (2, [DummyCallback(), dummy_function], False),
+    (2, None, True, {}),
+    (
+        3,
+        dummy_function,
+        False,
+        {"demix_filter": np.tile(-np.eye(3, dtype=np.complex128), reps=(n_bins, 1, 1))},
+    ),
+    (2, [DummyCallback(), dummy_function], False, {"demix_filter": None}),
 ]
 parameters_aux_fdica = [
-    (2, "IP", None),
-    (3, "IP1", dummy_function),
-    (2, "IP2", [DummyCallback(), dummy_function]),
+    (2, "IP", None, {}),
+    (
+        3,
+        "IP1",
+        dummy_function,
+        {"demix_filter": np.tile(-np.eye(3, dtype=np.complex128), reps=(n_bins, 1, 1))},
+    ),
+    (2, "IP2", [DummyCallback(), dummy_function], {"demix_filter": None}),
 ]
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_fdica)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_fdica)
 def test_grad_fdica(
     n_sources: int,
     callbacks: Optional[Union[Callable[[GradFDICA], None], List[Callable[[GradFDICA], None]]]],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -78,13 +91,14 @@ def test_grad_fdica(
     print(fdica)
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_fdica)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_fdica)
 def test_natural_grad_fdica(
     n_sources: int,
     callbacks: Optional[
         Union[Callable[[NaturalGradFDICA], None], List[Callable[[NaturalGradFDICA], None]]]
     ],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -116,11 +130,14 @@ def test_natural_grad_fdica(
     print(fdica)
 
 
-@pytest.mark.parametrize("n_sources, algorithm_spatial, callbacks", parameters_aux_fdica)
+@pytest.mark.parametrize(
+    "n_sources, algorithm_spatial, callbacks, reset_kwargs", parameters_aux_fdica
+)
 def test_aux_fdica(
     n_sources: int,
     algorithm_spatial: str,
     callbacks: Optional[Union[Callable[[AuxFDICA], None], List[Callable[[AuxFDICA], None]]]],
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -154,13 +171,14 @@ def test_aux_fdica(
     print(fdica)
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_fdica)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_fdica)
 def test_grad_laplace_fdica(
     n_sources: int,
     callbacks: Optional[
         Union[Callable[[GradLaplaceFDICA], None], List[Callable[[GradLaplaceFDICA], None]]]
     ],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -183,7 +201,7 @@ def test_grad_laplace_fdica(
     print(fdica)
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_fdica)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_fdica)
 def test_natural_grad_laplace_fdica(
     n_sources: int,
     callbacks: Optional[
@@ -193,6 +211,7 @@ def test_natural_grad_laplace_fdica(
         ]
     ],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -215,13 +234,16 @@ def test_natural_grad_laplace_fdica(
     print(fdica)
 
 
-@pytest.mark.parametrize("n_sources, algorithm_spatial, callbacks", parameters_aux_fdica)
+@pytest.mark.parametrize(
+    "n_sources, algorithm_spatial, callbacks, reset_kwargs", parameters_aux_fdica
+)
 def test_aux_laplace_fdica(
     n_sources: int,
     algorithm_spatial: str,
     callbacks: Optional[
         Union[Callable[[AuxLaplaceFDICA], None], List[Callable[[AuxLaplaceFDICA], None]]]
     ],
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 

--- a/tests/bss/test_ica.py
+++ b/tests/bss/test_ica.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Callable, List
+from typing import Optional, Union, Callable, List, Dict, Any
 
 import pytest
 import numpy as np
@@ -23,22 +23,23 @@ class DummyCallback:
 
 
 parameters_grad_ica = [
-    (2, None, True),
-    (3, dummy_function, False),
-    (2, [DummyCallback(), dummy_function], False),
+    (2, None, True, {}),
+    (3, dummy_function, False, {"demix_filter": -np.eye(3)}),
+    (2, [DummyCallback(), dummy_function], False, {"demix_filter": None}),
 ]
 parameters_fast_ica = [
-    (2, None),
-    (3, dummy_function),
-    (2, [DummyCallback(), dummy_function]),
+    (2, None, {}),
+    (3, dummy_function, {"demix_filter": -np.eye(3)}),
+    (2, [DummyCallback(), dummy_function], {"demix_filter": None}),
 ]
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_ica)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_ica)
 def test_grad_ica(
     n_sources: int,
     callbacks: Optional[Union[Callable[[GradICA], None], List[Callable[[GradICA], None]]]],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -68,11 +69,12 @@ def test_grad_ica(
     assert waveform_mix.shape == waveform_est.shape
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_ica)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_ica)
 def test_natural_grad_ica(
     n_sources: int,
     callbacks: Optional[Union[Callable[[GradICA], None], List[Callable[[GradICA], None]]]],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -102,11 +104,12 @@ def test_natural_grad_ica(
     assert waveform_mix.shape == waveform_est.shape
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_ica)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_ica)
 def test_grad_laplace_ica(
     n_sources: int,
     callbacks: Optional[Union[Callable[[GradICA], None], List[Callable[[GradICA], None]]]],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -127,11 +130,12 @@ def test_grad_laplace_ica(
     assert waveform_mix.shape == waveform_est.shape
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_ica)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_ica)
 def test_natural_grad_laplace_ica(
     n_sources: int,
     callbacks: Optional[Union[Callable[[GradICA], None], List[Callable[[GradICA], None]]]],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -152,10 +156,11 @@ def test_natural_grad_laplace_ica(
     assert waveform_mix.shape == waveform_est.shape
 
 
-@pytest.mark.parametrize("n_sources, callbacks", parameters_fast_ica)
+@pytest.mark.parametrize("n_sources, callbacks, reset_kwargs", parameters_fast_ica)
 def test_fast_ica(
     n_sources: int,
     callbacks: Optional[Union[Callable[[FastICA], None], List[Callable[[FastICA], None]]]],
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 

--- a/tests/bss/test_iva.py
+++ b/tests/bss/test_iva.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Callable, List
+from typing import Optional, Union, Callable, List, Dict, Any
 
 import pytest
 import numpy as np
@@ -15,6 +15,8 @@ from ssspy.bss.iva import (
 from ssspy.utils.dataset import download_dummy_data
 
 max_samples = 16000
+n_fft = 2048
+n_bins = n_fft // 2 + 1
 n_iter = 5
 
 
@@ -31,26 +33,44 @@ class DummyCallback:
 
 
 parameters_grad_iva = [
-    (2, None, True),
-    (3, dummy_function, False),
-    (2, [DummyCallback(), dummy_function], False),
+    (2, None, True, {}),
+    (
+        3,
+        dummy_function,
+        False,
+        {"demix_filter": np.tile(-np.eye(3, dtype=np.complex128), reps=(n_bins, 1, 1))},
+    ),
+    (2, [DummyCallback(), dummy_function], False, {"demix_filter": None}),
 ]
 
 parameters_aux_iva = [
-    (2, "dev1_female3", "IP", None),
-    (3, "dev1_female3", "IP2", dummy_function),
-    (2, "dev1_female3", "IP1", [DummyCallback(), dummy_function]),
-    (2, "dev1_female3", "ISS", None),
-    (3, "dev1_female3", "ISS1", dummy_function),
-    (4, "dev1_female4", "ISS2", [DummyCallback(), dummy_function]),
+    (2, "dev1_female3", "IP", None, {}),
+    (
+        3,
+        "dev1_female3",
+        "IP2",
+        dummy_function,
+        {"demix_filter": np.tile(-np.eye(3, dtype=np.complex128), reps=(n_bins, 1, 1))},
+    ),
+    (2, "dev1_female3", "IP1", [DummyCallback(), dummy_function], {"demix_filter": None}),
+    (2, "dev1_female3", "ISS", None, {}),
+    (
+        3,
+        "dev1_female3",
+        "ISS1",
+        dummy_function,
+        {"demix_filter": np.tile(-np.eye(3, dtype=np.complex128), reps=(n_bins, 1, 1))},
+    ),
+    (4, "dev1_female4", "ISS2", [DummyCallback(), dummy_function], {"demix_filter": None}),
 ]
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_iva)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_iva)
 def test_grad_iva(
     n_sources: int,
     callbacks: Optional[Union[Callable[[GradIVA], None], List[Callable[[GradIVA], None]]]],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -103,13 +123,14 @@ def test_grad_iva(
     print(iva)
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_iva)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_iva)
 def test_natural_grad_iva(
     n_sources: int,
     callbacks: Optional[
         Union[Callable[[NaturalGradIVA], None], List[Callable[[NaturalGradIVA], None]]]
     ],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -163,13 +184,14 @@ def test_natural_grad_iva(
 
 
 @pytest.mark.parametrize(
-    "n_sources, sisec2010_tag, algorithm_spatial, callbacks", parameters_aux_iva
+    "n_sources, sisec2010_tag, algorithm_spatial, callbacks, reset_kwargs", parameters_aux_iva
 )
 def test_aux_iva(
     n_sources: int,
     sisec2010_tag: str,
     algorithm_spatial: str,
     callbacks: Optional[Union[Callable[[AuxIVA], None], List[Callable[[AuxIVA], None]]]],
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -223,13 +245,14 @@ def test_aux_iva(
     print(iva)
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_iva)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_iva)
 def test_grad_laplace_iva(
     n_sources: int,
     callbacks: Optional[
         Union[Callable[[GradLaplaceIVA], None], List[Callable[[GradLaplaceIVA], None]]]
     ],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -252,7 +275,7 @@ def test_grad_laplace_iva(
     print(iva)
 
 
-@pytest.mark.parametrize("n_sources, callbacks, is_holonomic", parameters_grad_iva)
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_iva)
 def test_natural_grad_laplace_iva(
     n_sources: int,
     callbacks: Optional[
@@ -261,6 +284,7 @@ def test_natural_grad_laplace_iva(
         ]
     ],
     is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 
@@ -284,7 +308,7 @@ def test_natural_grad_laplace_iva(
 
 
 @pytest.mark.parametrize(
-    "n_sources, sisec2010_tag, algorithm_spatial, callbacks", parameters_aux_iva
+    "n_sources, sisec2010_tag, algorithm_spatial, callbacks, reset_kwargs", parameters_aux_iva
 )
 def test_aux_laplace_iva(
     n_sources: int,
@@ -295,6 +319,7 @@ def test_aux_laplace_iva(
             Callable[[NaturalGradLaplaceIVA], None], List[Callable[[NaturalGradLaplaceIVA], None]]
         ]
     ],
+    reset_kwargs: Dict[Any, Any],
 ):
     np.random.seed(111)
 


### PR DESCRIPTION
## Summary
Reset `demix_filter` when it isn't `None`.
So far, we try to copy even if it is `None`, which caused an error. Now, I've fixed it.

close #37