### PR TITLE
Whitening for real input

### DIFF
--- a/ssspy/transform/whiten.py
+++ b/ssspy/transform/whiten.py
@@ -5,14 +5,32 @@ def whiten(input: np.ndarray):
     r"""
     Args:
         input (numpy.ndarray):
-            Input tensor with shape of (n_channels, n_bins, n_frames).
+            Real tensor with shape of (n_channels, n_samples)
+            or complex tensor with shape of (n_channels, n_bins, n_frames).
 
     Returns:
         numpy.ndarray:
-            Output tensor with shape of (n_channels, n_bins, n_frames).
+            Whitened tensor.
+            Real tensor with shape of (n_channels, n_samples)
+            or complex tensor with shape of (n_channels, n_bins, n_frames).
     """
-    if input.ndim == 3:
+    if input.ndim == 2:
+        assert not np.iscomplexobj(input), "Input should be real."
+
+        n_channels, _ = input.shape
+
+        X = input.transpose(1, 0)
+        covariance = np.mean(X[:, :, np.newaxis] * X[:, np.newaxis, :], axis=0)
+        W, V = np.linalg.eigh(covariance)
+        D_diag = 1 / np.sqrt(W)
+        D_diag = np.diag(D_diag)
+        V_Hermite = V.transpose(1, 0)
+        output = D_diag @ V_Hermite @ X.transpose(1, 0)
+    elif input.ndim == 3:
+        assert np.iscomplexobj(input), "Input should be complex object."
+
         n_channels, _, _ = input.shape
+
         X = input.transpose(1, 2, 0)
         covariance = np.mean(X[:, :, :, np.newaxis] * X[:, :, np.newaxis, :].conj(), axis=1)
         W, V = np.linalg.eigh(covariance)

--- a/tests/transform/test_whiten.py
+++ b/tests/transform/test_whiten.py
@@ -3,11 +3,31 @@ import numpy as np
 
 from ssspy.transform import whiten
 
-parameters_whiten = [(2, 2049, 8), (3, 513, 12)]
+parameters_n_channels = [2, 3]
+parameters_whiten_real = [10, 20]
+parameters_whiten_complex = [(2049, 8), (513, 12)]
 
 
-@pytest.mark.parametrize("n_channels, n_bins, n_frames", parameters_whiten)
-def test_whiten(n_channels: int, n_bins: int, n_frames: int):
+@pytest.mark.parametrize("n_channels", parameters_n_channels)
+@pytest.mark.parametrize("n_samples", parameters_whiten_real)
+def test_whiten_real(n_channels: int, n_samples: int):
+    np.random.seed(111)
+
+    input = np.random.randn(n_channels, n_samples)
+    output = whiten(input)
+
+    assert input.shape == output.shape
+
+    covariance = output[:, np.newaxis, :] * output[np.newaxis, :, :]
+    covariance = np.mean(covariance, axis=-1)
+    eye = np.eye(n_channels)
+
+    assert np.allclose(covariance, eye)
+
+
+@pytest.mark.parametrize("n_channels", parameters_n_channels)
+@pytest.mark.parametrize("n_bins, n_frames", parameters_whiten_complex)
+def test_whiten_complex(n_channels: int, n_bins: int, n_frames: int):
     np.random.seed(111)
 
     real = np.random.randn(n_channels, n_bins, n_frames)


### PR DESCRIPTION
## Summary
Implement whitening for real input.
Input shape is `(n_channels, n_samples)`.

This implementation may help us to use time-domain ICA.

close #65 