### PR TITLE
Upload coverage only once in multiple tests

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -43,6 +43,7 @@ jobs:
         run: |
           pytest --cov=./ssspy --cov-report=xml
       - name: Upload coverage to codecov
+        if: matrix.os == 'ubuntu-latest' && ${{ matrix.python-version }} == 3.10
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary
Upload coverage only when `Ubuntu` and `python 3.10`.

https://github.com/tky823/ssspy/blob/f5b68afb6ec07123a6d22ad0267fb4f4079c2746/.github/workflows/test_package.yaml#L45-L49