### PR TITLE
Use numpy.linalg.slogdet

### DIFF
--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -216,12 +216,27 @@ class FDICAbase:
         """
         X, W = self.input, self.demix_filter
         Y = self.separate(X, demix_filter=W)  # (n_sources, n_bins, n_frames)
-        logdet = np.log(np.abs(np.linalg.det(W)))  # (n_bins,)
+        logdet = self.compute_logdet(W)  # (n_bins,)
         G = self.contrast_fn(Y)  # (n_sources, n_bins, n_frames)
         loss = np.sum(np.mean(G, axis=2), axis=0) - 2 * logdet
         loss = loss.sum(axis=0)
 
         return loss
+
+    def compute_logdet(self, demix_filter: np.ndarray) -> np.ndarray:
+        r"""Compute log-determinant of demixing filter
+
+        Args:
+            demix_filter (numpy.ndarray):
+                Demixing filters with shape of (n_bins, n_sources, n_channels).
+
+        Returns:
+            numpy.ndarray:
+                Computed log-determinant values.
+        """
+        _, logdet = np.linalg.slogdet(demix_filter)  # (n_bins,)
+
+        return logdet
 
     def solve_permutation(self) -> None:
         r"""Solve permutaion of estimated spectrograms.

--- a/ssspy/bss/ica.py
+++ b/ssspy/bss/ica.py
@@ -195,11 +195,26 @@ class GradICAbase:
         """
         X, W = self.input, self.demix_filter
         Y = self.separate(X, demix_filter=W)  # (n_channels, n_samples)
-        logdet = np.log(np.abs(np.linalg.det(W)))
+        logdet = self.compute_logdet(W)
         G = self.contrast_fn(Y)
         loss = np.sum(np.mean(G, axis=1)) - logdet
 
         return loss
+
+    def compute_logdet(self, demix_filter: np.ndarray) -> np.ndarray:
+        r"""Compute log-determinant of demixing filter
+
+        Args:
+            demix_filter (numpy.ndarray):
+                Demixing filter with shape of (n_sources, n_channels).
+
+        Returns:
+            numpy.ndarray:
+                Computed log-determinant value.
+        """
+        _, logdet = np.linalg.slogdet(demix_filter)  # (n_bins,)
+
+        return logdet
 
 
 class FastICAbase:

--- a/ssspy/bss/ilrma.py
+++ b/ssspy/bss/ilrma.py
@@ -459,8 +459,18 @@ class ILRMAbase:
 
     def compute_logdet(self, demix_filter: np.ndarray) -> np.ndarray:
         r"""Compute log-determinant of demixing filter
+
+        Args:
+            demix_filter (numpy.ndarray):
+                Demixing filters with shape of (n_bins, n_sources, n_channels).
+
+        Returns:
+            numpy.ndarray:
+                Computed log-determinant values.
         """
-        return np.log(np.abs(np.linalg.det(demix_filter)))  # (n_bins,)
+        _, logdet = np.linalg.slogdet(demix_filter)  # (n_bins,)
+
+        return logdet
 
     def apply_projection_back(self) -> None:
         r"""Apply projection back technique to estimated spectrograms.

--- a/ssspy/bss/iva.py
+++ b/ssspy/bss/iva.py
@@ -219,8 +219,18 @@ class IVAbase:
 
     def compute_logdet(self, demix_filter: np.ndarray) -> np.ndarray:
         r"""Compute log-determinant of demixing filter
+
+        Args:
+            demix_filter (numpy.ndarray):
+                Demixing filters with shape of (n_bins, n_sources, n_channels).
+
+        Returns:
+            numpy.ndarray:
+                Computed log-determinant values.
         """
-        return np.log(np.abs(np.linalg.det(demix_filter)))  # (n_bins,)
+        _, logdet = np.linalg.slogdet(demix_filter)  # (n_bins,)
+
+        return logdet
 
     def apply_projection_back(self) -> None:
         r"""Apply projection back technique to estimated spectrograms.


### PR DESCRIPTION
## Summary
So far, we used `np.log(np.abs(np.linalg.det(W)))`, but `np.linalg.slogdet(W)` is more stable.

close #77 