### PR TITLE
Rename should_*

### DIFF
--- a/ssspy/bss/_solve_permutation.py
+++ b/ssspy/bss/_solve_permutation.py
@@ -1,0 +1,96 @@
+from typing import Optional, Callable
+import itertools
+import functools
+
+import numpy as np
+
+from ._flooring import max_flooring
+
+EPS = 1e-10
+
+
+def _identity(x: np.ndarray) -> np.ndarray:
+    return x
+
+
+def correlation_based_permutation_solver(
+    separated: np.ndarray,
+    demix_filter: np.ndarray = None,
+    flooring_fn: Optional[Callable[[np.ndarray], np.ndarray]] = functools.partial(
+        max_flooring, eps=EPS
+    ),
+    overwrite: bool = True,
+) -> np.ndarray:
+    r"""Solve permutaion of estimated spectrograms.
+
+        Group channels at each frequency bin according to correlations
+        between frequencies [#sawada2010underdetermined]_.
+
+    Args:
+        separated (numpy.ndarray):
+            Separated spectrograms with shape of (n_sources, n_bins, n_frames).
+        demix_filter (numpy.ndarray):
+            Demixing filters with shape of (n_bins, n_sources, n_channels).
+        flooring_fn (callable, optional):
+            A flooring function for numerical stability.
+            This function is expected to receive (n_channels, n_bins, n_frames)
+            and return (n_channels, n_bins, n_frames).
+            If you explicitly set ``flooring_fn=None``, \
+            the identity function (``lambda x: x``) is used.
+            Default: ``partial(max_flooring, eps=1e-10)``.
+        overwrite (bool):
+            Overwrite ``demix_filter`` if ``overwrite=True``. \
+            Default: ``True``.
+
+    Returns:
+        numpy.ndarray:
+            Permutated demixing filters with shape of (n_bins, n_sources, n_channels).
+
+        .. [#sawada2010underdetermined]
+            H. Sawada, S. Araki, and S. Makino,
+            "Underdetermined convolutive blind source separation \
+            via frequency bin-wise clustering and permutation alignment,"
+            in *IEEE Trans. ASLP*, vol. 19, no. 3, pp. 516-527, 2010.
+    """
+    Y = separated
+
+    if overwrite:
+        W = demix_filter
+    else:
+        W = demix_filter.copy()
+
+    if flooring_fn is None:
+        flooring_fn = _identity
+    else:
+        flooring_fn = flooring_fn
+
+    n_bins, _, n_sources = W.shape
+
+    permutations = list(itertools.permutations(range(n_sources)))
+
+    P = np.abs(Y).transpose(1, 0, 2)
+    norm = np.sqrt(np.sum(P ** 2, axis=1, keepdims=True))
+    norm = flooring_fn(norm)
+    P = P / norm
+    correlation = np.sum(P @ P.transpose(0, 2, 1), axis=(1, 2))
+    indices = np.argsort(correlation)
+
+    min_idx = indices[0]
+    P_criteria = P[min_idx]
+
+    for bin_idx in range(1, n_bins):
+        min_idx = indices[bin_idx]
+        P_max = None
+        perm_max = None
+
+        for perm in permutations:
+            P_perm = np.sum(P_criteria * P[min_idx, perm, :])
+
+            if P_max is None or P_perm > P_max:
+                P_max = P_perm
+                perm_max = perm
+
+        P_criteria = P_criteria + P[min_idx, perm_max, :]
+        W[min_idx, :, :] = W[min_idx, perm_max, :]
+
+    return W

--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -46,9 +46,9 @@ class FDICAbase:
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -66,7 +66,7 @@ class FDICAbase:
         ] = None,
         should_solve_permutation: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         if contrast_fn is None:
@@ -95,9 +95,9 @@ class FDICAbase:
         else:
             self.reference_id = reference_id
 
-        self.should_record_loss = should_record_loss
+        self.record_loss = record_loss
 
-        if self.should_record_loss:
+        if self.record_loss:
             self.loss = []
         else:
             self.loss = None
@@ -128,7 +128,7 @@ class FDICAbase:
         s = "FDICA("
         s += ", should_solve_permutation={should_solve_permutation}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -327,9 +327,9 @@ class GradFDICAbase(FDICAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -349,7 +349,7 @@ class GradFDICAbase(FDICAbase):
         ] = None,
         should_solve_permutation: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
@@ -358,7 +358,7 @@ class GradFDICAbase(FDICAbase):
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -389,7 +389,7 @@ class GradFDICAbase(FDICAbase):
 
         self._reset(**kwargs)
 
-        if self.should_record_loss:
+        if self.record_loss:
             loss = self.compute_loss()
             self.loss.append(loss)
 
@@ -400,7 +400,7 @@ class GradFDICAbase(FDICAbase):
         for _ in range(n_iter):
             self.update_once()
 
-            if self.should_record_loss:
+            if self.record_loss:
                 loss = self.compute_loss()
                 self.loss.append(loss)
 
@@ -423,7 +423,7 @@ class GradFDICAbase(FDICAbase):
         s += "step_size={step_size}"
         s += ", should_solve_permutation={should_solve_permutation}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -472,9 +472,9 @@ class GradFDICA(GradFDICAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -515,7 +515,7 @@ class GradFDICA(GradFDICAbase):
         is_holonomic: bool = False,
         should_solve_permutation: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
@@ -526,7 +526,7 @@ class GradFDICA(GradFDICAbase):
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -538,7 +538,7 @@ class GradFDICA(GradFDICAbase):
         s += ", is_holonomic={is_holonomic}"
         s += ", should_solve_permutation={should_solve_permutation}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -636,9 +636,9 @@ class NaturalGradFDICA(GradFDICAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -679,7 +679,7 @@ class NaturalGradFDICA(GradFDICAbase):
         is_holonomic: bool = False,
         should_solve_permutation: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
@@ -690,7 +690,7 @@ class NaturalGradFDICA(GradFDICAbase):
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -702,7 +702,7 @@ class NaturalGradFDICA(GradFDICAbase):
         s += ", is_holonomic={is_holonomic}"
         s += ", should_solve_permutation={should_solve_permutation}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -801,9 +801,9 @@ class AuxFDICA(FDICAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -847,7 +847,7 @@ class AuxFDICA(FDICAbase):
         ] = None,
         should_solve_permutation: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
@@ -856,7 +856,7 @@ class AuxFDICA(FDICAbase):
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
         assert algorithm_spatial in algorithms_spatial, "Not support {}.".format(algorithms_spatial)
@@ -889,7 +889,7 @@ class AuxFDICA(FDICAbase):
 
         self._reset(**kwargs)
 
-        if self.should_record_loss:
+        if self.record_loss:
             loss = self.compute_loss()
             self.loss.append(loss)
 
@@ -900,7 +900,7 @@ class AuxFDICA(FDICAbase):
         for _ in range(n_iter):
             self.update_once()
 
-            if self.should_record_loss:
+            if self.record_loss:
                 loss = self.compute_loss()
                 self.loss.append(loss)
 
@@ -923,7 +923,7 @@ class AuxFDICA(FDICAbase):
         s += "algorithm_spatial={algorithm_spatial}"
         s += ", should_solve_permutation={should_solve_permutation}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -1104,9 +1104,9 @@ class GradLaplaceFDICA(GradFDICA):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -1138,7 +1138,7 @@ class GradLaplaceFDICA(GradFDICA):
         is_holonomic: bool = False,
         should_solve_permutation: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         def contrast_fn(y: np.ndarray) -> np.ndarray:
@@ -1177,7 +1177,7 @@ class GradLaplaceFDICA(GradFDICA):
             is_holonomic=is_holonomic,
             should_solve_permutation=should_solve_permutation,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -1187,7 +1187,7 @@ class GradLaplaceFDICA(GradFDICA):
         s += ", is_holonomic={is_holonomic}"
         s += ", should_solve_permutation={should_solve_permutation}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -1228,9 +1228,9 @@ class NaturalGradLaplaceFDICA(GradFDICA):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -1265,7 +1265,7 @@ class NaturalGradLaplaceFDICA(GradFDICA):
         is_holonomic: bool = False,
         should_solve_permutation: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         def contrast_fn(y: np.ndarray) -> np.ndarray:
@@ -1304,7 +1304,7 @@ class NaturalGradLaplaceFDICA(GradFDICA):
             is_holonomic=is_holonomic,
             should_solve_permutation=should_solve_permutation,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -1314,7 +1314,7 @@ class NaturalGradLaplaceFDICA(GradFDICA):
         s += ", is_holonomic={is_holonomic}"
         s += ", should_solve_permutation={should_solve_permutation}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -1358,9 +1358,9 @@ class AuxLaplaceFDICA(AuxFDICA):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -1379,7 +1379,7 @@ class AuxLaplaceFDICA(AuxFDICA):
         ] = None,
         should_solve_permutation: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         def contrast_fn(y: np.ndarray):
@@ -1397,7 +1397,7 @@ class AuxLaplaceFDICA(AuxFDICA):
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -1406,7 +1406,7 @@ class AuxLaplaceFDICA(AuxFDICA):
         s += "algorithm_spatial={algorithm_spatial}"
         s += ", should_solve_permutation={should_solve_permutation}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"

--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -43,8 +43,8 @@ class FDICAbase:
         should_solve_permutation (bool):
             If ``should_solve_permutation=True``, a permutation solver is used to align \
             estimated spectrograms. Default: ``True``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -65,7 +65,7 @@ class FDICAbase:
             Union[Callable[["FDICAbase"], None], List[Callable[["FDICAbase"], None]]]
         ] = None,
         should_solve_permutation: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -88,10 +88,10 @@ class FDICAbase:
 
         self.input = None
         self.should_solve_permutation = should_solve_permutation
-        self.should_apply_projection_back = should_apply_projection_back
+        self.use_projection_back = use_projection_back
 
-        if reference_id is None and should_apply_projection_back:
-            raise ValueError("Specify 'reference_id' if should_apply_projection_back=True.")
+        if reference_id is None and use_projection_back:
+            raise ValueError("Specify 'reference_id' if use_projection_back=True.")
         else:
             self.reference_id = reference_id
 
@@ -127,10 +127,10 @@ class FDICAbase:
     def __repr__(self) -> str:
         s = "FDICA("
         s += ", should_solve_permutation={should_solve_permutation}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -287,7 +287,7 @@ class FDICAbase:
     def apply_projection_back(self) -> None:
         r"""Apply projection back technique to estimated spectrograms.
         """
-        assert self.should_apply_projection_back, "Set self.should_apply_projection_back=True."
+        assert self.use_projection_back, "Set self.use_projection_back=True."
 
         X, W = self.input, self.demix_filter
         W_scaled = projection_back(W, reference_id=self.reference_id)
@@ -324,8 +324,8 @@ class GradFDICAbase(FDICAbase):
         should_solve_permutation (bool):
             If ``should_solve_permutation=True``, a permutation solver is used to align \
             estimated spectrograms. Default: ``True``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the gradient descent \
@@ -348,7 +348,7 @@ class GradFDICAbase(FDICAbase):
             Union[Callable[["GradFDICAbase"], None], List[Callable[["GradFDICAbase"], None]]]
         ] = None,
         should_solve_permutation: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -357,7 +357,7 @@ class GradFDICAbase(FDICAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -411,7 +411,7 @@ class GradFDICAbase(FDICAbase):
         if self.should_solve_permutation:
             self.solve_permutation()
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             self.apply_projection_back()
 
         self.output = self.separate(self.input, demix_filter=self.demix_filter)
@@ -422,10 +422,10 @@ class GradFDICAbase(FDICAbase):
         s = "GradFDICA("
         s += "step_size={step_size}"
         s += ", should_solve_permutation={should_solve_permutation}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -469,8 +469,8 @@ class GradFDICA(GradFDICAbase):
         should_solve_permutation (bool):
             If ``should_solve_permutation=True``, a permutation solver is used to align \
             estimated spectrograms. Default: ``True``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the gradient descent \
@@ -514,7 +514,7 @@ class GradFDICA(GradFDICAbase):
         ] = None,
         is_holonomic: bool = False,
         should_solve_permutation: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -525,7 +525,7 @@ class GradFDICA(GradFDICAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -537,10 +537,10 @@ class GradFDICA(GradFDICAbase):
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
         s += ", should_solve_permutation={should_solve_permutation}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -633,8 +633,8 @@ class NaturalGradFDICA(GradFDICAbase):
         should_solve_permutation (bool):
             If ``should_solve_permutation=True``, a permutation solver is used to align \
             estimated spectrograms. Default: ``True``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the gradient descent \
@@ -678,7 +678,7 @@ class NaturalGradFDICA(GradFDICAbase):
         ] = None,
         is_holonomic: bool = False,
         should_solve_permutation: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -689,7 +689,7 @@ class NaturalGradFDICA(GradFDICAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -701,10 +701,10 @@ class NaturalGradFDICA(GradFDICAbase):
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
         s += ", should_solve_permutation={should_solve_permutation}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -798,8 +798,8 @@ class AuxFDICA(FDICAbase):
         should_solve_permutation (bool):
             If ``should_solve_permutation=True``, a permutation solver is used to align \
             estimated spectrograms. Default: ``True``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the gradient descent \
@@ -846,7 +846,7 @@ class AuxFDICA(FDICAbase):
             Union[Callable[["AuxFDICA"], None], List[Callable[["AuxFDICA"], None]]]
         ] = None,
         should_solve_permutation: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -855,7 +855,7 @@ class AuxFDICA(FDICAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -911,7 +911,7 @@ class AuxFDICA(FDICAbase):
         if self.should_solve_permutation:
             self.solve_permutation()
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             self.apply_projection_back()
 
         self.output = self.separate(self.input, demix_filter=self.demix_filter)
@@ -922,10 +922,10 @@ class AuxFDICA(FDICAbase):
         s = "AuxFDICA("
         s += "algorithm_spatial={algorithm_spatial}"
         s += ", should_solve_permutation={should_solve_permutation}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -1101,8 +1101,8 @@ class GradLaplaceFDICA(GradFDICA):
         should_solve_permutation (bool):
             If ``should_solve_permutation=True``, a permutation solver is used to align \
             estimated spectrograms. Default: ``True``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the gradient descent \
@@ -1137,7 +1137,7 @@ class GradLaplaceFDICA(GradFDICA):
         ] = None,
         is_holonomic: bool = False,
         should_solve_permutation: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -1176,7 +1176,7 @@ class GradLaplaceFDICA(GradFDICA):
             callbacks=callbacks,
             is_holonomic=is_holonomic,
             should_solve_permutation=should_solve_permutation,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -1186,10 +1186,10 @@ class GradLaplaceFDICA(GradFDICA):
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
         s += ", should_solve_permutation={should_solve_permutation}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -1225,8 +1225,8 @@ class NaturalGradLaplaceFDICA(GradFDICA):
         should_solve_permutation (bool):
             If ``should_solve_permutation=True``, a permutation solver is used to align \
             estimated spectrograms. Default: ``True``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the gradient descent \
@@ -1264,7 +1264,7 @@ class NaturalGradLaplaceFDICA(GradFDICA):
         ] = None,
         is_holonomic: bool = False,
         should_solve_permutation: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -1303,7 +1303,7 @@ class NaturalGradLaplaceFDICA(GradFDICA):
             callbacks=callbacks,
             is_holonomic=is_holonomic,
             should_solve_permutation=should_solve_permutation,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -1313,10 +1313,10 @@ class NaturalGradLaplaceFDICA(GradFDICA):
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
         s += ", should_solve_permutation={should_solve_permutation}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -1355,8 +1355,8 @@ class AuxLaplaceFDICA(AuxFDICA):
         should_solve_permutation (bool):
             If ``should_solve_permutation=True``, a permutation solver is used to align \
             estimated spectrograms. Default: ``True``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the gradient descent \
@@ -1378,7 +1378,7 @@ class AuxLaplaceFDICA(AuxFDICA):
             Union[Callable[["AuxLaplaceFDICA"], None], List[Callable[["AuxLaplaceFDICA"], None]]]
         ] = None,
         should_solve_permutation: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -1396,7 +1396,7 @@ class AuxLaplaceFDICA(AuxFDICA):
             pair_selector=pair_selector,
             callbacks=callbacks,
             should_solve_permutation=should_solve_permutation,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -1405,10 +1405,10 @@ class AuxLaplaceFDICA(AuxFDICA):
         s = "AuxLaplaceFDICA("
         s += "algorithm_spatial={algorithm_spatial}"
         s += ", should_solve_permutation={should_solve_permutation}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"

--- a/ssspy/bss/ica.py
+++ b/ssspy/bss/ica.py
@@ -321,7 +321,7 @@ class FastICAbase:
                     callback(self)
 
         self.output = self.separate(
-            self.whitened_input, demix_filter=self.demix_filter, should_whiten=False
+            self.whitened_input, demix_filter=self.demix_filter, whiten=False
         )
 
         return self.output
@@ -379,12 +379,10 @@ class FastICAbase:
         """
         raise NotImplementedError("Implement 'update_once' method.")
 
-    def separate(
-        self, input: np.ndarray, demix_filter: np.ndarray, should_whiten=True
-    ) -> np.ndarray:
+    def separate(self, input: np.ndarray, demix_filter: np.ndarray, whiten=True) -> np.ndarray:
         r"""Separate ``input`` using ``demixing_filter``.
 
-        If ``should_whiten=True``,
+        If ``whiten=True``,
 
         .. math::
             \boldsymbol{y}_{t}
@@ -405,7 +403,7 @@ class FastICAbase:
         :math:`\sum_{t}\boldsymbol{x}_{t}\boldsymbol{x}_{t}^{\mathsf{T}}`,
         respectively.
 
-        Otherwise (``should_whiten=False``),
+        Otherwise (``whiten=False``),
 
         .. math::
             \boldsymbol{y}_{t}
@@ -418,8 +416,8 @@ class FastICAbase:
             demix_filter (numpy.ndarray):
                 The demixing filters to separate ``input``.
                 The shape is (n_sources, n_channels).
-            should_whiten (bool):
-                If ``should_whiten=True``, whitening (sphering) is applied to ``input``.
+            whiten (bool):
+                If ``whiten=True``, whitening (sphering) is applied to ``input``.
                 Default: True.
 
         Returns:
@@ -427,7 +425,7 @@ class FastICAbase:
                 The separated signal in time-domain.
                 The shape is (n_sources, n_samples).
         """
-        if should_whiten:
+        if whiten:
             X = input
             XX_trans = np.mean(X[:, np.newaxis, :] * X[np.newaxis, :, :], axis=-1)
             lamb, Gamma = np.linalg.eigh(XX_trans)  # (n_channels,), (n_channels, n_channels)
@@ -457,7 +455,7 @@ class FastICAbase:
                 Computed loss.
         """
         Z, W = self.whitened_input, self.demix_filter
-        Y = self.separate(Z, demix_filter=W, should_whiten=False)
+        Y = self.separate(Z, demix_filter=W, whiten=False)
 
         loss = np.mean(self.contrast_fn(Y), axis=-1)
         loss = loss.sum()
@@ -844,7 +842,7 @@ class FastICA(FastICAbase):
             norm = np.linalg.norm(w_n)
             W[src_idx] = w_n / norm
 
-        Y = self.separate(Z, demix_filter=W, should_whiten=False)
+        Y = self.separate(Z, demix_filter=W, whiten=False)
 
         self.demix_filter = W
         self.output = Y

--- a/ssspy/bss/ica.py
+++ b/ssspy/bss/ica.py
@@ -22,9 +22,9 @@ class GradICAbase:
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
     """
 
@@ -36,7 +36,7 @@ class GradICAbase:
         callbacks: Optional[
             Union[Callable[["GradICAbase"], None], List[Callable[["GradICAbase"], None]]]
         ] = None,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
     ) -> None:
         self.step_size = step_size
 
@@ -58,9 +58,9 @@ class GradICAbase:
             self.callbacks = None
 
         self.input = None
-        self.should_record_loss = should_record_loss
+        self.record_loss = record_loss
 
-        if self.should_record_loss:
+        if self.record_loss:
             self.loss = []
         else:
             self.loss = None
@@ -85,7 +85,7 @@ class GradICAbase:
 
         self._reset(**kwargs)
 
-        if self.should_record_loss:
+        if self.record_loss:
             loss = self.compute_loss()
             self.loss.append(loss)
 
@@ -96,7 +96,7 @@ class GradICAbase:
         for _ in range(n_iter):
             self.update_once()
 
-            if self.should_record_loss:
+            if self.record_loss:
                 loss = self.compute_loss()
                 self.loss.append(loss)
 
@@ -111,7 +111,7 @@ class GradICAbase:
     def __repr__(self) -> str:
         s = "GradICA("
         s += "step_size={step_size}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
         s += ")"
 
         return s.format(**self.__dict__)
@@ -235,9 +235,9 @@ class FastICAbase:
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each of the fixed-point iteration \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
     """
 
@@ -249,7 +249,7 @@ class FastICAbase:
         callbacks: Optional[
             Union[Callable[["FastICAbase"], None], List[Callable[["FastICAbase"], None]]]
         ] = None,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
     ) -> None:
         if contrast_fn is None:
             raise ValueError("Specify contrast function.")
@@ -274,9 +274,9 @@ class FastICAbase:
             self.callbacks = None
 
         self.input = None
-        self.should_record_loss = should_record_loss
+        self.record_loss = record_loss
 
-        if self.should_record_loss:
+        if self.record_loss:
             self.loss = []
         else:
             self.loss = None
@@ -301,7 +301,7 @@ class FastICAbase:
 
         self._reset(**kwargs)
 
-        if self.should_record_loss:
+        if self.record_loss:
             loss = self.compute_loss()
             self.loss.append(loss)
 
@@ -312,7 +312,7 @@ class FastICAbase:
         for _ in range(n_iter):
             self.update_once()
 
-            if self.should_record_loss:
+            if self.record_loss:
                 loss = self.compute_loss()
                 self.loss.append(loss)
 
@@ -328,7 +328,7 @@ class FastICAbase:
 
     def __repr__(self) -> str:
         s = "FastICA("
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
         s += ")"
 
         return s.format(**self.__dict__)
@@ -485,9 +485,9 @@ class GradICA(GradICAbase):
         is_holonomic (bool):
             If ``is_holonomic=True``, Holonomic-type update is used.
             Otherwise, Nonholonomic-type update is used. Default: ``False``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
 
     Examples:
@@ -517,14 +517,14 @@ class GradICA(GradICAbase):
             Union[Callable[["GradICA"], None], List[Callable[["GradICA"], None]]]
         ] = None,
         is_holonomic: bool = False,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
     ) -> None:
         super().__init__(
             step_size=step_size,
             contrast_fn=contrast_fn,
             score_fn=score_fn,
             callbacks=callbacks,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
         )
 
         self.is_holonomic = is_holonomic
@@ -533,7 +533,7 @@ class GradICA(GradICAbase):
         s = "GradICA("
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
         s += ")"
 
         return s.format(**self.__dict__)
@@ -609,9 +609,9 @@ class NaturalGradICA(GradICAbase):
         is_holonomic (bool):
             If ``is_holonomic=True``, Holonomic-type update is used.
             Otherwise, Nonholonomic-type update is used. Default: ``False``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
 
     Examples:
@@ -645,14 +645,14 @@ class NaturalGradICA(GradICAbase):
             Union[Callable[["GradICA"], None], List[Callable[["GradICA"], None]]]
         ] = None,
         is_holonomic: bool = False,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
     ) -> None:
         super().__init__(
             step_size=step_size,
             contrast_fn=contrast_fn,
             score_fn=score_fn,
             callbacks=callbacks,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
         )
 
         self.is_holonomic = is_holonomic
@@ -661,7 +661,7 @@ class NaturalGradICA(GradICAbase):
         s = "NaturalGradICA("
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
         s += ")"
 
         return s.format(**self.__dict__)
@@ -758,9 +758,9 @@ class FastICA(FastICAbase):
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each of the fixed-point iteration \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
 
     Examples:
@@ -797,14 +797,14 @@ class FastICA(FastICAbase):
         callbacks: Optional[
             Union[Callable[["FastICA"], None], List[Callable[["FastICA"], None]]]
         ] = None,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
     ) -> None:
         super().__init__(
             contrast_fn=contrast_fn,
             score_fn=score_fn,
             d_score_fn=d_score_fn,
             callbacks=callbacks,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
         )
 
     def update_once(self) -> None:
@@ -867,9 +867,9 @@ class GradLaplaceICA(GradICA):
         is_holonomic (bool):
             If ``is_holonomic=True``, Holonomic-type update is used.
             Otherwise, Nonholonomic-type update is used. Default: ``False``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
 
     Examples:
@@ -891,7 +891,7 @@ class GradLaplaceICA(GradICA):
             Union[Callable[["GradLaplaceICA"], None], List[Callable[["GradLaplaceICA"], None]]]
         ] = None,
         is_holonomic: bool = False,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
     ) -> None:
         def contrast_fn(input):
             return np.abs(input)
@@ -905,14 +905,14 @@ class GradLaplaceICA(GradICA):
             score_fn=score_fn,
             callbacks=callbacks,
             is_holonomic=is_holonomic,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
         )
 
     def __repr__(self) -> str:
         s = "GradLaplaceICA("
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
         s += ")"
 
         return s.format(**self.__dict__)
@@ -980,9 +980,9 @@ class NaturalGradLaplaceICA(NaturalGradICA):
         is_holonomic (bool):
             If ``is_holonomic=True``, Holonomic-type update is used.
             Otherwise, Nonholonomic-type update is used. Default: ``False``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the gradient descent \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
 
     Examples:
@@ -1007,7 +1007,7 @@ class NaturalGradLaplaceICA(NaturalGradICA):
             ]
         ] = None,
         is_holonomic: bool = False,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
     ) -> None:
         def contrast_fn(input):
             return np.abs(input)
@@ -1021,14 +1021,14 @@ class NaturalGradLaplaceICA(NaturalGradICA):
             score_fn=score_fn,
             callbacks=callbacks,
             is_holonomic=is_holonomic,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
         )
 
     def __repr__(self) -> str:
         s = "NaturalGradLaplaceICA("
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
         s += ")"
 
         return s.format(**self.__dict__)

--- a/ssspy/bss/ilrma.py
+++ b/ssspy/bss/ilrma.py
@@ -32,8 +32,8 @@ class ILRMAbase:
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -63,7 +63,7 @@ class ILRMAbase:
         callbacks: Optional[
             Union[Callable[["ILRMAbase"], None], List[Callable[["ILRMAbase"], None]]]
         ] = None,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
         rng: np.random.Generator = np.random.default_rng(),
@@ -85,10 +85,10 @@ class ILRMAbase:
             self.callbacks = None
 
         self.input = None
-        self.should_apply_projection_back = should_apply_projection_back
+        self.use_projection_back = use_projection_back
 
-        if reference_id is None and should_apply_projection_back:
-            raise ValueError("Specify 'reference_id' if should_apply_projection_back=True.")
+        if reference_id is None and use_projection_back:
+            raise ValueError("Specify 'reference_id' if use_projection_back=True.")
         else:
             self.reference_id = reference_id
 
@@ -140,7 +140,7 @@ class ILRMAbase:
                 for callback in self.callbacks:
                     callback(self)
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             self.apply_projection_back()
 
         if self.algorithm_spatial in ["IP", "IP1", "IP2"]:
@@ -152,10 +152,10 @@ class ILRMAbase:
         s = "ILRMA("
         s += "n_basis={n_basis}"
         s += ", partitioning={partitioning}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -496,7 +496,7 @@ class ILRMAbase:
     def apply_projection_back(self) -> None:
         r"""Apply projection back technique to estimated spectrograms.
         """
-        assert self.should_apply_projection_back, "Set self.should_apply_projection_back=True."
+        assert self.use_projection_back, "Set self.use_projection_back=True."
 
         X, W = self.input, self.demix_filter
         W_scaled = projection_back(W, reference_id=self.reference_id)
@@ -536,8 +536,8 @@ class GaussILRMA(ILRMAbase):
             Normalization of demixing filters and NMF parameters.
             Choose "power" or "projection_back".
             Default: ``"power"``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -565,7 +565,7 @@ class GaussILRMA(ILRMAbase):
             Union[Callable[["GaussILRMA"], None], List[Callable[["GaussILRMA"], None]]]
         ] = None,
         normalization: Optional[Union[bool, str]] = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
         rng: np.random.Generator = np.random.default_rng(),
@@ -575,7 +575,7 @@ class GaussILRMA(ILRMAbase):
             partitioning=partitioning,
             flooring_fn=flooring_fn,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
             rng=rng,
@@ -600,10 +600,10 @@ class GaussILRMA(ILRMAbase):
         s += ", domain={domain}"
         s += ", partitioning={partitioning}"
         s += ", normalization={normalization}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -1109,7 +1109,7 @@ class GaussILRMA(ILRMAbase):
         if self.algorithm_spatial in ["IP", "IP1", "IP2"]:
             super().apply_projection_back()
         else:
-            assert self.should_apply_projection_back, "Set self.should_apply_projection_back=True."
+            assert self.use_projection_back, "Set self.use_projection_back=True."
 
             X, Y = self.input, self.output
             Y_scaled = projection_back(Y, reference=X, reference_id=self.reference_id)
@@ -1150,8 +1150,8 @@ class TILRMA(ILRMAbase):
             Normalization of demixing filters and NMF parameters.
             Choose "power" or "projection_back".
             Default: ``"power"``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -1180,7 +1180,7 @@ class TILRMA(ILRMAbase):
             Union[Callable[["TILRMA"], None], List[Callable[["TILRMA"], None]]]
         ] = None,
         normalization: Optional[Union[bool, str]] = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
         rng: np.random.Generator = np.random.default_rng(),
@@ -1190,7 +1190,7 @@ class TILRMA(ILRMAbase):
             partitioning=partitioning,
             flooring_fn=flooring_fn,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
             rng=rng,
@@ -1217,10 +1217,10 @@ class TILRMA(ILRMAbase):
         s += ", domain={domain}"
         s += ", partitioning={partitioning}"
         s += ", normalization={normalization}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -1768,7 +1768,7 @@ class TILRMA(ILRMAbase):
         if self.algorithm_spatial in ["IP", "IP1", "IP2"]:
             super().apply_projection_back()
         else:
-            assert self.should_apply_projection_back, "Set self.should_apply_projection_back=True."
+            assert self.use_projection_back, "Set self.use_projection_back=True."
 
             X, Y = self.input, self.output
             Y_scaled = projection_back(Y, reference=X, reference_id=self.reference_id)
@@ -1809,8 +1809,8 @@ class GGDILRMA(ILRMAbase):
             Normalization of demixing filters and NMF parameters.
             Choose "power" or "projection_back".
             Default: ``"power"``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -1839,7 +1839,7 @@ class GGDILRMA(ILRMAbase):
             Union[Callable[["GGDILRMA"], None], List[Callable[["GGDILRMA"], None]]]
         ] = None,
         normalization: Optional[Union[bool, str]] = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
         rng: np.random.Generator = np.random.default_rng(),
@@ -1849,7 +1849,7 @@ class GGDILRMA(ILRMAbase):
             partitioning=partitioning,
             flooring_fn=flooring_fn,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
             rng=rng,
@@ -1877,10 +1877,10 @@ class GGDILRMA(ILRMAbase):
         s += ", domain={domain}"
         s += ", partitioning={partitioning}"
         s += ", normalization={normalization}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -2388,7 +2388,7 @@ class GGDILRMA(ILRMAbase):
         if self.algorithm_spatial in ["IP", "IP1", "IP2"]:
             super().apply_projection_back()
         else:
-            assert self.should_apply_projection_back, "Set self.should_apply_projection_back=True."
+            assert self.use_projection_back, "Set self.use_projection_back=True."
 
             X, Y = self.input, self.output
             Y_scaled = projection_back(Y, reference=X, reference_id=self.reference_id)

--- a/ssspy/bss/ilrma.py
+++ b/ssspy/bss/ilrma.py
@@ -35,9 +35,9 @@ class ILRMAbase:
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -64,7 +64,7 @@ class ILRMAbase:
             Union[Callable[["ILRMAbase"], None], List[Callable[["ILRMAbase"], None]]]
         ] = None,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
         rng: np.random.Generator = np.random.default_rng(),
     ) -> None:
@@ -94,9 +94,9 @@ class ILRMAbase:
 
         self.rng = rng
 
-        self.should_record_loss = should_record_loss
+        self.record_loss = record_loss
 
-        if self.should_record_loss:
+        if self.record_loss:
             self.loss = []
         else:
             self.loss = None
@@ -121,7 +121,7 @@ class ILRMAbase:
 
         self._reset(**kwargs)
 
-        if self.should_record_loss:
+        if self.record_loss:
             loss = self.compute_loss()
             self.loss.append(loss)
 
@@ -132,7 +132,7 @@ class ILRMAbase:
         for _ in range(n_iter):
             self.update_once()
 
-            if self.should_record_loss:
+            if self.record_loss:
                 loss = self.compute_loss()
                 self.loss.append(loss)
 
@@ -153,7 +153,7 @@ class ILRMAbase:
         s += "n_basis={n_basis}"
         s += ", partitioning={partitioning}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -539,9 +539,9 @@ class GaussILRMA(ILRMAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -566,7 +566,7 @@ class GaussILRMA(ILRMAbase):
         ] = None,
         normalization: Optional[Union[bool, str]] = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
         rng: np.random.Generator = np.random.default_rng(),
     ) -> None:
@@ -576,7 +576,7 @@ class GaussILRMA(ILRMAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
             rng=rng,
         )
@@ -601,7 +601,7 @@ class GaussILRMA(ILRMAbase):
         s += ", partitioning={partitioning}"
         s += ", normalization={normalization}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -1153,9 +1153,9 @@ class TILRMA(ILRMAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -1181,7 +1181,7 @@ class TILRMA(ILRMAbase):
         ] = None,
         normalization: Optional[Union[bool, str]] = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
         rng: np.random.Generator = np.random.default_rng(),
     ) -> None:
@@ -1191,7 +1191,7 @@ class TILRMA(ILRMAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
             rng=rng,
         )
@@ -1218,7 +1218,7 @@ class TILRMA(ILRMAbase):
         s += ", partitioning={partitioning}"
         s += ", normalization={normalization}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -1812,9 +1812,9 @@ class GGDILRMA(ILRMAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -1840,7 +1840,7 @@ class GGDILRMA(ILRMAbase):
         ] = None,
         normalization: Optional[Union[bool, str]] = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
         rng: np.random.Generator = np.random.default_rng(),
     ) -> None:
@@ -1850,7 +1850,7 @@ class GGDILRMA(ILRMAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
             rng=rng,
         )
@@ -1878,7 +1878,7 @@ class GGDILRMA(ILRMAbase):
         s += ", partitioning={partitioning}"
         s += ", normalization={normalization}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"

--- a/ssspy/bss/iva.py
+++ b/ssspy/bss/iva.py
@@ -40,8 +40,8 @@ class IVAbase:
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -65,7 +65,7 @@ class IVAbase:
         callbacks: Optional[
             Union[Callable[["IVAbase"], None], List[Callable[["IVAbase"], None]]]
         ] = None,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -82,10 +82,10 @@ class IVAbase:
             self.callbacks = None
 
         self.input = None
-        self.should_apply_projection_back = should_apply_projection_back
+        self.use_projection_back = use_projection_back
 
-        if reference_id is None and should_apply_projection_back:
-            raise ValueError("Specify 'reference_id' if should_apply_projection_back=True.")
+        if reference_id is None and use_projection_back:
+            raise ValueError("Specify 'reference_id' if use_projection_back=True.")
         else:
             self.reference_id = reference_id
 
@@ -120,10 +120,10 @@ class IVAbase:
 
     def __repr__(self) -> str:
         s = "IVA("
-        s += "should_apply_projection_back={should_apply_projection_back}"
+        s += "use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -236,7 +236,7 @@ class IVAbase:
     def apply_projection_back(self) -> None:
         r"""Apply projection back technique to estimated spectrograms.
         """
-        assert self.should_apply_projection_back, "Set self.should_apply_projection_back=True."
+        assert self.use_projection_back, "Set self.use_projection_back=True."
 
         X, W = self.input, self.demix_filter
         W_scaled = projection_back(W, reference_id=self.reference_id)
@@ -271,8 +271,8 @@ class GradIVAbase(IVAbase):
         is_holonomic (bool):
             If ``is_holonomic=True``, Holonomic-type update is used.
             Otherwise, Nonholonomic-type update is used. Default: ``False``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -295,14 +295,14 @@ class GradIVAbase(IVAbase):
             Union[Callable[["GradIVAbase"], None], List[Callable[["GradIVAbase"], None]]]
         ] = None,
         is_holonomic: bool = False,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -359,7 +359,7 @@ class GradIVAbase(IVAbase):
                 for callback in self.callbacks:
                     callback(self)
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             self.apply_projection_back()
 
         self.output = self.separate(self.input, demix_filter=self.demix_filter)
@@ -370,10 +370,10 @@ class GradIVAbase(IVAbase):
         s = "GradIVA("
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -408,24 +408,24 @@ class FastIVAbase(IVAbase):
         callbacks: Optional[
             Union[Callable[["IVAbase"], None], List[Callable[["IVAbase"], None]]]
         ] = None,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
 
     def __repr__(self) -> str:
         s = "FastIVA("
-        s += "should_apply_projection_back={should_apply_projection_back}"
+        s += "use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -475,8 +475,8 @@ class AuxIVAbase(IVAbase):
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -497,14 +497,14 @@ class AuxIVAbase(IVAbase):
         callbacks: Optional[
             Union[Callable[["AuxIVAbase"], None], List[Callable[["AuxIVAbase"], None]]]
         ] = None,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -531,10 +531,10 @@ class AuxIVAbase(IVAbase):
 
     def __repr__(self) -> str:
         s = "AuxIVA("
-        s += "should_apply_projection_back={should_apply_projection_back}"
+        s += "use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -568,8 +568,8 @@ class GradIVA(GradIVAbase):
         is_holonomic (bool):
             If ``is_holonomic=True``, Holonomic-type update is used.
             Otherwise, Nonholonomic-type update is used. Default: ``False``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -611,7 +611,7 @@ class GradIVA(GradIVAbase):
             Union[Callable[["GradIVA"], None], List[Callable[["GradIVA"], None]]]
         ] = None,
         is_holonomic: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -622,7 +622,7 @@ class GradIVA(GradIVAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             is_holonomic=is_holonomic,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -710,8 +710,8 @@ class NaturalGradIVA(GradIVAbase):
         is_holonomic (bool):
             If ``is_holonomic=True``, Holonomic-type update is used.
             Otherwise, Nonholonomic-type update is used. Default: ``False``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -753,7 +753,7 @@ class NaturalGradIVA(GradIVAbase):
             Union[Callable[["NaturalGradIVA"], None], List[Callable[["NaturalGradIVA"], None]]]
         ] = None,
         is_holonomic: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -764,7 +764,7 @@ class NaturalGradIVA(GradIVAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             is_holonomic=is_holonomic,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -849,8 +849,8 @@ class FastIVA(FastIVAbase):
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration. \
             Default: ``None``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -887,7 +887,7 @@ class FastIVA(FastIVAbase):
                     contrast_fn=contrast_fn,
                     d_contrast_fn=d_contrast_fn,
                     dd_contrast_fn=dd_contrast_fn,
-                    should_apply_projection_back=False,
+                    use_projection_back=False,
             )
             spectrogram_est = iva(spectrogram_mix, n_iter=100)
             print(spectrogram_mix.shape, spectrogram_est.shape)
@@ -911,14 +911,14 @@ class FastIVA(FastIVAbase):
         callbacks: Optional[
             Union[Callable[["FastIVA"], None], List[Callable[["FastIVA"], None]]]
         ] = None,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -977,7 +977,7 @@ class FastIVA(FastIVAbase):
                 for callback in self.callbacks:
                     callback(self)
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             self.apply_projection_back()
 
         self.output = self.separate(self.input, demix_filter=self.demix_filter)
@@ -986,10 +986,10 @@ class FastIVA(FastIVAbase):
 
     def __repr__(self) -> str:
         s = "FastIVA("
-        s += "should_apply_projection_back={should_apply_projection_back}"
+        s += "use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -1046,8 +1046,8 @@ class FasterIVA(FastIVAbase):
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -1073,14 +1073,14 @@ class FasterIVA(FastIVAbase):
         callbacks: Optional[
             Union[Callable[["FasterIVA"], None], List[Callable[["FasterIVA"], None]]]
         ] = None,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -1133,7 +1133,7 @@ class FasterIVA(FastIVAbase):
                 for callback in self.callbacks:
                     callback(self)
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             self.apply_projection_back()
 
         self.output = self.separate(self.input, demix_filter=self.demix_filter)
@@ -1142,10 +1142,10 @@ class FasterIVA(FastIVAbase):
 
     def __repr__(self) -> str:
         s = "FasterIVA("
-        s += "should_apply_projection_back={should_apply_projection_back}"
+        s += "use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -1202,8 +1202,8 @@ class AuxIVA(AuxIVAbase):
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -1244,7 +1244,7 @@ class AuxIVA(AuxIVAbase):
         callbacks: Optional[
             Union[Callable[["AuxIVA"], None], List[Callable[["AuxIVA"], None]]]
         ] = None,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ):
@@ -1253,7 +1253,7 @@ class AuxIVA(AuxIVAbase):
             d_contrast_fn=d_contrast_fn,
             flooring_fn=flooring_fn,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -1306,7 +1306,7 @@ class AuxIVA(AuxIVAbase):
                 for callback in self.callbacks:
                     callback(self)
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             self.apply_projection_back()
 
         if self.algorithm_spatial in ["IP", "IP1", "IP2"]:
@@ -1317,10 +1317,10 @@ class AuxIVA(AuxIVAbase):
     def __repr__(self) -> str:
         s = "AuxIVA("
         s += "algorithm_spatial={algorithm_spatial}"
-        s += ", should_apply_projection_back={should_apply_projection_back}"
+        s += ", use_projection_back={use_projection_back}"
         s += ", should_record_loss={should_record_loss}"
 
-        if self.should_apply_projection_back:
+        if self.use_projection_back:
             s += ", reference_id={reference_id}"
 
         s += ")"
@@ -1591,7 +1591,7 @@ class AuxIVA(AuxIVAbase):
         if self.algorithm_spatial in ["IP", "IP1", "IP2"]:
             super().apply_projection_back()
         else:
-            assert self.should_apply_projection_back, "Set self.should_apply_projection_back=True."
+            assert self.use_projection_back, "Set self.use_projection_back=True."
 
             X, Y = self.input, self.output
             Y_scaled = projection_back(Y, reference=X, reference_id=self.reference_id)
@@ -1622,8 +1622,8 @@ class GradLaplaceIVA(GradIVA):
         is_holonomic (bool):
             If ``is_holonomic=True``, Holonomic-type update is used.
             Otherwise, Nonholonomic-type update is used. Default: ``False``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -1656,7 +1656,7 @@ class GradLaplaceIVA(GradIVA):
             Union[Callable[["GradLaplaceIVA"], None], List[Callable[["GradLaplaceIVA"], None]]]
         ] = None,
         is_holonomic: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -1695,7 +1695,7 @@ class GradLaplaceIVA(GradIVA):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             is_holonomic=is_holonomic,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -1761,7 +1761,7 @@ class GradGaussIVA(GradIVA):
             Union[Callable[["GradGaussIVA"], None], List[Callable[["GradGaussIVA"], None]]]
         ] = None,
         is_holonomic: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -1804,7 +1804,7 @@ class GradGaussIVA(GradIVA):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             is_holonomic=is_holonomic,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -1864,8 +1864,8 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
         is_holonomic (bool):
             If ``is_holonomic=True``, Holonomic-type update is used.
             Otherwise, Nonholonomic-type update is used. Default: ``False``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -1901,7 +1901,7 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
             ]
         ] = None,
         is_holonomic: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -1940,7 +1940,7 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             is_holonomic=is_holonomic,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -2009,7 +2009,7 @@ class NaturalGradGaussIVA(NaturalGradIVA):
             ]
         ] = None,
         is_holonomic: bool = True,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
@@ -2052,7 +2052,7 @@ class NaturalGradGaussIVA(NaturalGradIVA):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             is_holonomic=is_holonomic,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -2113,8 +2113,8 @@ class AuxLaplaceIVA(AuxIVA):
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -2147,7 +2147,7 @@ class AuxLaplaceIVA(AuxIVA):
         callbacks: Optional[
             Union[Callable[["AuxLaplaceIVA"], None], List[Callable[["AuxLaplaceIVA"], None]]]
         ] = None,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ):
@@ -2164,7 +2164,7 @@ class AuxLaplaceIVA(AuxIVA):
             flooring_fn=flooring_fn,
             pair_selector=pair_selector,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )
@@ -2195,8 +2195,8 @@ class AuxGaussIVA(AuxIVA):
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_apply_projection_back (bool):
-            If ``should_apply_projection_back=True``, the projection back is applied to \
+        use_projection_back (bool):
+            If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
         should_record_loss (bool):
             Record the loss at each iteration of the update algorithm \
@@ -2229,7 +2229,7 @@ class AuxGaussIVA(AuxIVA):
         callbacks: Optional[
             Union[Callable[["AuxGaussIVA"], None], List[Callable[["AuxGaussIVA"], None]]]
         ] = None,
-        should_apply_projection_back: bool = True,
+        use_projection_back: bool = True,
         should_record_loss: bool = True,
         reference_id: int = 0,
     ):
@@ -2271,7 +2271,7 @@ class AuxGaussIVA(AuxIVA):
             flooring_fn=flooring_fn,
             pair_selector=pair_selector,
             callbacks=callbacks,
-            should_apply_projection_back=should_apply_projection_back,
+            use_projection_back=use_projection_back,
             should_record_loss=should_record_loss,
             reference_id=reference_id,
         )

--- a/ssspy/bss/iva.py
+++ b/ssspy/bss/iva.py
@@ -43,9 +43,9 @@ class IVAbase:
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -66,7 +66,7 @@ class IVAbase:
             Union[Callable[["IVAbase"], None], List[Callable[["IVAbase"], None]]]
         ] = None,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         if flooring_fn is None:
@@ -89,9 +89,9 @@ class IVAbase:
         else:
             self.reference_id = reference_id
 
-        self.should_record_loss = should_record_loss
+        self.record_loss = record_loss
 
-        if self.should_record_loss:
+        if self.record_loss:
             self.loss = []
         else:
             self.loss = None
@@ -121,7 +121,7 @@ class IVAbase:
     def __repr__(self) -> str:
         s = "IVA("
         s += "use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -274,9 +274,9 @@ class GradIVAbase(IVAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -296,14 +296,14 @@ class GradIVAbase(IVAbase):
         ] = None,
         is_holonomic: bool = False,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
         self.step_size = step_size
@@ -340,7 +340,7 @@ class GradIVAbase(IVAbase):
 
         self._reset(**kwargs)
 
-        if self.should_record_loss:
+        if self.record_loss:
             loss = self.compute_loss()
             self.loss.append(loss)
 
@@ -351,7 +351,7 @@ class GradIVAbase(IVAbase):
         for _ in range(n_iter):
             self.update_once()
 
-            if self.should_record_loss:
+            if self.record_loss:
                 loss = self.compute_loss()
                 self.loss.append(loss)
 
@@ -371,7 +371,7 @@ class GradIVAbase(IVAbase):
         s += "step_size={step_size}"
         s += ", is_holonomic={is_holonomic}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -394,9 +394,9 @@ class FastIVAbase(IVAbase):
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
     """
 
@@ -409,21 +409,21 @@ class FastIVAbase(IVAbase):
             Union[Callable[["IVAbase"], None], List[Callable[["IVAbase"], None]]]
         ] = None,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
     def __repr__(self) -> str:
         s = "FastIVA("
         s += "use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -478,9 +478,9 @@ class AuxIVAbase(IVAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -498,14 +498,14 @@ class AuxIVAbase(IVAbase):
             Union[Callable[["AuxIVAbase"], None], List[Callable[["AuxIVAbase"], None]]]
         ] = None,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
         self.contrast_fn = contrast_fn
@@ -532,7 +532,7 @@ class AuxIVAbase(IVAbase):
     def __repr__(self) -> str:
         s = "AuxIVA("
         s += "use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -571,9 +571,9 @@ class GradIVA(GradIVAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -612,7 +612,7 @@ class GradIVA(GradIVAbase):
         ] = None,
         is_holonomic: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
@@ -623,7 +623,7 @@ class GradIVA(GradIVAbase):
             callbacks=callbacks,
             is_holonomic=is_holonomic,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -713,9 +713,9 @@ class NaturalGradIVA(GradIVAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -754,7 +754,7 @@ class NaturalGradIVA(GradIVAbase):
         ] = None,
         is_holonomic: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
@@ -765,7 +765,7 @@ class NaturalGradIVA(GradIVAbase):
             callbacks=callbacks,
             is_holonomic=is_holonomic,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -852,9 +852,9 @@ class FastIVA(FastIVAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``. \
+            if ``record_loss=True``. \
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back. \
@@ -912,14 +912,14 @@ class FastIVA(FastIVAbase):
             Union[Callable[["FastIVA"], None], List[Callable[["FastIVA"], None]]]
         ] = None,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -958,7 +958,7 @@ class FastIVA(FastIVAbase):
 
         self._reset(**kwargs)
 
-        if self.should_record_loss:
+        if self.record_loss:
             loss = self.compute_loss()
             self.loss.append(loss)
 
@@ -969,7 +969,7 @@ class FastIVA(FastIVAbase):
         for _ in range(n_iter):
             self.update_once()
 
-            if self.should_record_loss:
+            if self.record_loss:
                 loss = self.compute_loss()
                 self.loss.append(loss)
 
@@ -987,7 +987,7 @@ class FastIVA(FastIVAbase):
     def __repr__(self) -> str:
         s = "FastIVA("
         s += "use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -1049,9 +1049,9 @@ class FasterIVA(FastIVAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -1074,14 +1074,14 @@ class FasterIVA(FastIVAbase):
             Union[Callable[["FasterIVA"], None], List[Callable[["FasterIVA"], None]]]
         ] = None,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         super().__init__(
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
         if contrast_fn is None:
@@ -1114,7 +1114,7 @@ class FasterIVA(FastIVAbase):
 
         self._reset(**kwargs)
 
-        if self.should_record_loss:
+        if self.record_loss:
             loss = self.compute_loss()
             self.loss.append(loss)
 
@@ -1125,7 +1125,7 @@ class FasterIVA(FastIVAbase):
         for _ in range(n_iter):
             self.update_once()
 
-            if self.should_record_loss:
+            if self.record_loss:
                 loss = self.compute_loss()
                 self.loss.append(loss)
 
@@ -1143,7 +1143,7 @@ class FasterIVA(FastIVAbase):
     def __repr__(self) -> str:
         s = "FasterIVA("
         s += "use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -1205,9 +1205,9 @@ class AuxIVA(AuxIVAbase):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -1245,7 +1245,7 @@ class AuxIVA(AuxIVAbase):
             Union[Callable[["AuxIVA"], None], List[Callable[["AuxIVA"], None]]]
         ] = None,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ):
         super().__init__(
@@ -1254,7 +1254,7 @@ class AuxIVA(AuxIVAbase):
             flooring_fn=flooring_fn,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -1287,7 +1287,7 @@ class AuxIVA(AuxIVAbase):
 
         self._reset(**kwargs)
 
-        if self.should_record_loss:
+        if self.record_loss:
             loss = self.compute_loss()
             self.loss.append(loss)
 
@@ -1298,7 +1298,7 @@ class AuxIVA(AuxIVAbase):
         for _ in range(n_iter):
             self.update_once()
 
-            if self.should_record_loss:
+            if self.record_loss:
                 loss = self.compute_loss()
                 self.loss.append(loss)
 
@@ -1318,7 +1318,7 @@ class AuxIVA(AuxIVAbase):
         s = "AuxIVA("
         s += "algorithm_spatial={algorithm_spatial}"
         s += ", use_projection_back={use_projection_back}"
-        s += ", should_record_loss={should_record_loss}"
+        s += ", record_loss={record_loss}"
 
         if self.use_projection_back:
             s += ", reference_id={reference_id}"
@@ -1625,9 +1625,9 @@ class GradLaplaceIVA(GradIVA):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -1657,7 +1657,7 @@ class GradLaplaceIVA(GradIVA):
         ] = None,
         is_holonomic: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         def contrast_fn(y: np.ndarray) -> np.ndarray:
@@ -1696,7 +1696,7 @@ class GradLaplaceIVA(GradIVA):
             callbacks=callbacks,
             is_holonomic=is_holonomic,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -1762,7 +1762,7 @@ class GradGaussIVA(GradIVA):
         ] = None,
         is_holonomic: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         def contrast_fn(y: np.ndarray) -> np.ndarray:
@@ -1805,7 +1805,7 @@ class GradGaussIVA(GradIVA):
             callbacks=callbacks,
             is_holonomic=is_holonomic,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -1867,9 +1867,9 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -1902,7 +1902,7 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
         ] = None,
         is_holonomic: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         def contrast_fn(y: np.ndarray) -> np.ndarray:
@@ -1941,7 +1941,7 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
             callbacks=callbacks,
             is_holonomic=is_holonomic,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -2010,7 +2010,7 @@ class NaturalGradGaussIVA(NaturalGradIVA):
         ] = None,
         is_holonomic: bool = True,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
         def contrast_fn(y: np.ndarray) -> np.ndarray:
@@ -2053,7 +2053,7 @@ class NaturalGradGaussIVA(NaturalGradIVA):
             callbacks=callbacks,
             is_holonomic=is_holonomic,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -2116,9 +2116,9 @@ class AuxLaplaceIVA(AuxIVA):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -2148,7 +2148,7 @@ class AuxLaplaceIVA(AuxIVA):
             Union[Callable[["AuxLaplaceIVA"], None], List[Callable[["AuxLaplaceIVA"], None]]]
         ] = None,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ):
         def contrast_fn(y):
@@ -2165,7 +2165,7 @@ class AuxLaplaceIVA(AuxIVA):
             pair_selector=pair_selector,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 
@@ -2198,9 +2198,9 @@ class AuxGaussIVA(AuxIVA):
         use_projection_back (bool):
             If ``use_projection_back=True``, the projection back is applied to \
             estimated spectrograms. Default: ``True``.
-        should_record_loss (bool):
+        record_loss (bool):
             Record the loss at each iteration of the update algorithm \
-            if ``should_record_loss=True``.
+            if ``record_loss=True``.
             Default: ``True``.
         reference_id (int):
             Reference channel for projection back.
@@ -2230,7 +2230,7 @@ class AuxGaussIVA(AuxIVA):
             Union[Callable[["AuxGaussIVA"], None], List[Callable[["AuxGaussIVA"], None]]]
         ] = None,
         use_projection_back: bool = True,
-        should_record_loss: bool = True,
+        record_loss: bool = True,
         reference_id: int = 0,
     ):
         def contrast_fn(y: np.ndarray) -> np.ndarray:
@@ -2272,7 +2272,7 @@ class AuxGaussIVA(AuxIVA):
             pair_selector=pair_selector,
             callbacks=callbacks,
             use_projection_back=use_projection_back,
-            should_record_loss=should_record_loss,
+            record_loss=record_loss,
             reference_id=reference_id,
         )
 

--- a/tests/bss/test_fdica.py
+++ b/tests/bss/test_fdica.py
@@ -4,14 +4,9 @@ import pytest
 import numpy as np
 import scipy.signal as ss
 
-from ssspy.bss.fdica import (
-    GradFDICA,
-    NaturalGradFDICA,
-    GradLaplaceFDICA,
-    NaturalGradLaplaceFDICA,
-    AuxFDICA,
-    AuxLaplaceFDICA,
-)
+from ssspy.bss.fdica import GradFDICAbase, GradFDICA, GradLaplaceFDICA
+from ssspy.bss.fdica import NaturalGradFDICA, NaturalGradLaplaceFDICA
+from ssspy.bss.fdica import AuxFDICA, AuxLaplaceFDICA
 from ssspy.utils.dataset import download_sample_speech_data
 from tests.dummy.callback import DummyCallback, dummy_function
 
@@ -41,6 +36,29 @@ parameters_aux_fdica = [
     ),
     (2, "IP2", [DummyCallback(), dummy_function], {"demix_filter": None}),
 ]
+
+
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_fdica)
+def test_grad_fdica_base(
+    n_sources: int,
+    callbacks: Optional[Union[Callable[[GradFDICA], None], List[Callable[[GradFDICA], None]]]],
+    is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
+):
+    np.random.seed(111)
+
+    def contrast_fn(y):
+        return 2 * np.abs(y)
+
+    def score_fn(y):
+        denominator = np.maximum(np.abs(y), 1e-10)
+        return y / denominator
+
+    fdica = GradFDICAbase(
+        contrast_fn=contrast_fn, score_fn=score_fn, callbacks=callbacks, is_holonomic=is_holonomic
+    )
+
+    print(fdica)
 
 
 @pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_fdica)

--- a/tests/bss/test_fdica.py
+++ b/tests/bss/test_fdica.py
@@ -54,9 +54,7 @@ def test_grad_fdica_base(
         denominator = np.maximum(np.abs(y), 1e-10)
         return y / denominator
 
-    fdica = GradFDICAbase(
-        contrast_fn=contrast_fn, score_fn=score_fn, callbacks=callbacks, is_holonomic=is_holonomic
-    )
+    fdica = GradFDICAbase(contrast_fn=contrast_fn, score_fn=score_fn, callbacks=callbacks)
 
     print(fdica)
 

--- a/tests/bss/test_ica.py
+++ b/tests/bss/test_ica.py
@@ -3,7 +3,8 @@ from typing import Optional, Union, Callable, List, Dict, Any
 import pytest
 import numpy as np
 
-from ssspy.bss.ica import GradICA, NaturalGradICA, GradLaplaceICA, NaturalGradLaplaceICA
+from ssspy.bss.ica import GradICAbase, GradICA, GradLaplaceICA
+from ssspy.bss.ica import NaturalGradICA, NaturalGradLaplaceICA
 from ssspy.bss.ica import FastICA
 from ssspy.utils.dataset import download_sample_speech_data
 from tests.dummy.callback import DummyCallback, dummy_function
@@ -21,6 +22,24 @@ parameters_fast_ica = [
     (3, dummy_function, {"demix_filter": -np.eye(3)}),
     (2, [DummyCallback(), dummy_function], {"demix_filter": None}),
 ]
+
+
+@pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_ica)
+def test_grad_ica_base(
+    n_sources: int,
+    callbacks: Optional[Union[Callable[[GradICA], None], List[Callable[[GradICA], None]]]],
+    is_holonomic: bool,
+    reset_kwargs: Dict[Any, Any],
+):
+    def contrast_fn(x):
+        return np.log(1 + np.exp(x))
+
+    def score_fn(x):
+        return 1 / (1 + np.exp(-x))
+
+    ica = GradICAbase(contrast_fn=contrast_fn, score_fn=score_fn, callbacks=callbacks)
+
+    print(ica)
 
 
 @pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_ica)
@@ -49,10 +68,11 @@ def test_grad_ica(
     ica = GradICA(
         contrast_fn=contrast_fn, score_fn=score_fn, callbacks=callbacks, is_holonomic=is_holonomic
     )
-
     waveform_est = ica(waveform_mix, n_iter=n_iter)
 
     assert waveform_mix.shape == waveform_est.shape
+
+    print(ica)
 
 
 @pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_ica)
@@ -81,10 +101,11 @@ def test_natural_grad_ica(
     ica = NaturalGradICA(
         contrast_fn=contrast_fn, score_fn=score_fn, callbacks=callbacks, is_holonomic=is_holonomic
     )
-
     waveform_est = ica(waveform_mix, n_iter=n_iter)
 
     assert waveform_mix.shape == waveform_est.shape
+
+    print(ica)
 
 
 @pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_ica)
@@ -109,6 +130,8 @@ def test_grad_laplace_ica(
 
     assert waveform_mix.shape == waveform_est.shape
 
+    print(ica)
+
 
 @pytest.mark.parametrize("n_sources, callbacks, is_holonomic, reset_kwargs", parameters_grad_ica)
 def test_natural_grad_laplace_ica(
@@ -131,6 +154,8 @@ def test_natural_grad_laplace_ica(
     waveform_est = ica(waveform_mix, n_iter=n_iter)
 
     assert waveform_mix.shape == waveform_est.shape
+
+    print(ica)
 
 
 @pytest.mark.parametrize("n_sources, callbacks, reset_kwargs", parameters_fast_ica)
@@ -162,7 +187,8 @@ def test_fast_ica(
     ica = FastICA(
         contrast_fn=contrast_fn, score_fn=score_fn, d_score_fn=d_score_fn, callbacks=callbacks
     )
-
     waveform_est = ica(waveform_mix, n_iter=n_iter)
 
     assert waveform_mix.shape == waveform_est.shape
+
+    print(ica)

--- a/tests/bss/test_ilrma.py
+++ b/tests/bss/test_ilrma.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 import scipy.signal as ss
 
-from ssspy.bss.ilrma import GaussILRMA, TILRMA, GGDILRMA
+from ssspy.bss.ilrma import ILRMAbase, GaussILRMA, TILRMA, GGDILRMA
 from ssspy.utils.dataset import download_sample_speech_data
 from tests.dummy.callback import DummyCallback, dummy_function
 
@@ -21,6 +21,7 @@ parameters_dof = [1, 100]
 parameters_beta = [0.5, 1.5]
 parameters_algorithm_spatial = ["IP", "IP1", "IP2", "ISS", "ISS1", "ISS2"]
 parameters_callbacks = [None, dummy_function, [DummyCallback(), dummy_function]]
+parameters_ilrma_base = [4, 3]
 parameters_ilrma_latent = [
     (
         2,
@@ -48,6 +49,21 @@ parameters_ilrma_wo_latent = [
 ]
 parameters_normalization_latent = [True, False, "power"]
 parameters_normalization_wo_latent = [True, False, "power", "projection_back"]
+
+
+@pytest.mark.parametrize(
+    "n_basis", parameters_ilrma_base,
+)
+@pytest.mark.parametrize("callbacks", parameters_callbacks)
+def test_ilrma_base(
+    n_basis: int,
+    callbacks: Optional[Union[Callable[[GaussILRMA], None], List[Callable[[GaussILRMA], None]]]],
+):
+    ilrma = ILRMAbase(
+        n_basis, partitioning=True, callbacks=callbacks, rng=np.random.default_rng(42),
+    )
+
+    print(ilrma)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
The parameter `should_*` is high in readability, but too long.
I renamed some parameters which start with `should_`.

close #106 