### PR TITLE
Fix type of return value in compute loss

### DIFF
--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -212,7 +212,7 @@ class FDICAbase(IterativeMethodBase):
         logdet = self.compute_logdet(W)  # (n_bins,)
         G = self.contrast_fn(Y)  # (n_sources, n_bins, n_frames)
         loss = np.sum(np.mean(G, axis=2), axis=0) - 2 * logdet
-        loss = loss.sum(axis=0)
+        loss = loss.sum(axis=0).item()
 
         return loss
 
@@ -771,7 +771,7 @@ class AuxFDICA(FDICAbase):
         .. code-block:: python
 
             def contrast_fn(y):
-                return 2 * y
+                return 2 * np.abs(y)
 
             def d_contrast_fn(y):
                 return 2 * np.ones_like(y)
@@ -1341,7 +1341,7 @@ class AuxLaplaceFDICA(AuxFDICA):
         reference_id: int = 0,
     ) -> None:
         def contrast_fn(y: np.ndarray):
-            return 2 * y
+            return 2 * np.abs(y)
 
         def d_contrast_fn(y: np.ndarray):
             return 2 * np.ones_like(y)

--- a/ssspy/bss/ica.py
+++ b/ssspy/bss/ica.py
@@ -172,6 +172,7 @@ class GradICAbase(IterativeMethodBase):
         logdet = self.compute_logdet(W)
         G = self.contrast_fn(Y)
         loss = np.sum(np.mean(G, axis=1)) - logdet
+        loss = loss.item()
 
         return loss
 
@@ -395,7 +396,7 @@ class FastICAbase(IterativeMethodBase):
         Y = self.separate(Z, demix_filter=W, use_whitening=False)
 
         loss = np.mean(self.contrast_fn(Y), axis=-1)
-        loss = loss.sum()
+        loss = loss.sum().item()
 
         return loss
 

--- a/ssspy/bss/ilrma.py
+++ b/ssspy/bss/ilrma.py
@@ -1234,7 +1234,7 @@ class GaussILRMA(ILRMAbase):
         logdet = self.compute_logdet(W)  # (n_bins,)
 
         loss = np.sum(loss.mean(axis=-1), axis=0) - 2 * logdet
-        loss = loss.sum(axis=0)
+        loss = loss.sum(axis=0).item()
 
         return loss
 
@@ -2049,7 +2049,7 @@ class TILRMA(ILRMAbase):
         logdet = self.compute_logdet(W)  # (n_bins,)
 
         loss = np.sum(loss.mean(axis=-1), axis=0) - 2 * logdet
-        loss = loss.sum(axis=0)
+        loss = loss.sum(axis=0).item()
 
         return loss
 
@@ -2846,7 +2846,7 @@ class GGDILRMA(ILRMAbase):
         logdet = self.compute_logdet(W)  # (n_bins,)
 
         loss = np.sum(loss.mean(axis=-1), axis=0) - 2 * logdet
-        loss = loss.sum(axis=0)
+        loss = loss.sum(axis=0).item()
 
         return loss
 

--- a/ssspy/bss/iva.py
+++ b/ssspy/bss/iva.py
@@ -206,6 +206,7 @@ class IVAbase(IterativeMethodBase):
         logdet = self.compute_logdet(W)  # (n_bins,)
         G = self.contrast_fn(Y)  # (n_sources, n_frames)
         loss = np.sum(np.mean(G, axis=1), axis=0) - 2 * np.sum(logdet, axis=0)
+        loss = loss.item()
 
         return loss
 
@@ -490,7 +491,7 @@ class FastIVAbase(IVAbase):
         Y = self.separate(Z, demix_filter=W, use_whitening=False)  # (n_sources, n_bins, n_frames)
 
         G = self.contrast_fn(Y)  # (n_sources, n_frames)
-        loss = np.sum(np.mean(G, axis=1), axis=0)
+        loss = np.sum(np.mean(G, axis=1), axis=0).item()
 
         return loss
 
@@ -1664,6 +1665,7 @@ class AuxIVA(AuxIVAbase):
             W = Y @ X_Hermite @ np.linalg.inv(XX_Hermite)
             logdet = self.compute_logdet(W)  # (n_bins,)
             loss = np.sum(np.mean(G, axis=1), axis=0) - 2 * np.sum(logdet, axis=0)
+            loss = loss.item()
 
             return loss
 

--- a/tests/ssspy/bss/test_fdica.py
+++ b/tests/ssspy/bss/test_fdica.py
@@ -98,6 +98,7 @@ def test_grad_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert isinstance(fdica.loss[-1], float)
 
     print(fdica)
 
@@ -142,6 +143,7 @@ def test_natural_grad_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert isinstance(fdica.loss[-1], float)
 
     print(fdica)
 
@@ -189,6 +191,7 @@ def test_aux_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert isinstance(fdica.loss[-1], float)
 
     print(fdica)
 
@@ -224,6 +227,7 @@ def test_grad_laplace_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert isinstance(fdica.loss[-1], float)
 
     print(fdica)
 
@@ -262,6 +266,7 @@ def test_natural_grad_laplace_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert isinstance(fdica.loss[-1], float)
 
     print(fdica)
 
@@ -303,5 +308,6 @@ def test_aux_laplace_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert isinstance(fdica.loss[-1], float)
 
     print(fdica)

--- a/tests/ssspy/bss/test_fdica.py
+++ b/tests/ssspy/bss/test_fdica.py
@@ -98,7 +98,7 @@ def test_grad_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
-    assert isinstance(fdica.loss[-1], float)
+    assert type(fdica.loss[-1]) is float
 
     print(fdica)
 
@@ -143,7 +143,7 @@ def test_natural_grad_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
-    assert isinstance(fdica.loss[-1], float)
+    assert type(fdica.loss[-1]) is float
 
     print(fdica)
 
@@ -191,7 +191,7 @@ def test_aux_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
-    assert isinstance(fdica.loss[-1], float)
+    assert type(fdica.loss[-1]) is float
 
     print(fdica)
 
@@ -227,7 +227,7 @@ def test_grad_laplace_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
-    assert isinstance(fdica.loss[-1], float)
+    assert type(fdica.loss[-1]) is float
 
     print(fdica)
 
@@ -266,7 +266,7 @@ def test_natural_grad_laplace_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
-    assert isinstance(fdica.loss[-1], float)
+    assert type(fdica.loss[-1]) is float
 
     print(fdica)
 
@@ -308,6 +308,6 @@ def test_aux_laplace_fdica(
     spectrogram_est = fdica(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
-    assert isinstance(fdica.loss[-1], float)
+    assert type(fdica.loss[-1]) is float
 
     print(fdica)

--- a/tests/ssspy/bss/test_ica.py
+++ b/tests/ssspy/bss/test_ica.py
@@ -81,6 +81,7 @@ def test_grad_ica(
     waveform_est = ica(waveform_mix, n_iter=n_iter)
 
     assert waveform_mix.shape == waveform_est.shape
+    assert type(ica.loss[-1]) is float
 
     print(ica)
 
@@ -116,6 +117,7 @@ def test_natural_grad_ica(
     waveform_est = ica(waveform_mix, n_iter=n_iter)
 
     assert waveform_mix.shape == waveform_est.shape
+    assert type(ica.loss[-1]) is float
 
     print(ica)
 
@@ -143,6 +145,7 @@ def test_grad_laplace_ica(
     waveform_est = ica(waveform_mix, n_iter=n_iter)
 
     assert waveform_mix.shape == waveform_est.shape
+    assert type(ica.loss[-1]) is float
 
     print(ica)
 
@@ -170,6 +173,7 @@ def test_natural_grad_laplace_ica(
     waveform_est = ica(waveform_mix, n_iter=n_iter)
 
     assert waveform_mix.shape == waveform_est.shape
+    assert type(ica.loss[-1]) is float
 
     print(ica)
 
@@ -207,5 +211,6 @@ def test_fast_ica(
     waveform_est = ica(waveform_mix, n_iter=n_iter)
 
     assert waveform_mix.shape == waveform_est.shape
+    assert type(ica.loss[-1]) is float
 
     print(ica)

--- a/tests/ssspy/bss/test_ilrma.py
+++ b/tests/ssspy/bss/test_ilrma.py
@@ -137,6 +137,7 @@ def test_gauss_ilrma_latent(
     spectrogram_est = ilrma(spectrogram_mix, n_iter=n_iter, **reset_kwargs)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(ilrma.loss[-1]) is float
 
     print(ilrma)
 
@@ -193,6 +194,7 @@ def test_gauss_ilrma_wo_latent(
     spectrogram_est = ilrma(spectrogram_mix, n_iter=n_iter, **reset_kwargs)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(ilrma.loss[-1]) is float
 
     print(ilrma)
 
@@ -252,6 +254,7 @@ def test_t_ilrma_latent(
     spectrogram_est = ilrma(spectrogram_mix, n_iter=n_iter, **reset_kwargs)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(ilrma.loss[-1]) is float
 
     print(ilrma)
 
@@ -311,6 +314,7 @@ def test_t_ilrma_wo_latent(
     spectrogram_est = ilrma(spectrogram_mix, n_iter=n_iter, **reset_kwargs)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(ilrma.loss[-1]) is float
 
     print(ilrma)
 
@@ -370,6 +374,7 @@ def test_ggd_ilrma_latent(
     spectrogram_est = ilrma(spectrogram_mix, n_iter=n_iter, **reset_kwargs)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(ilrma.loss[-1]) is float
 
     print(ilrma)
 
@@ -429,5 +434,6 @@ def test_ggd_ilrma_wo_latent(
     spectrogram_est = ilrma(spectrogram_mix, n_iter=n_iter, **reset_kwargs)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(ilrma.loss[-1]) is float
 
     print(ilrma)

--- a/tests/ssspy/bss/test_iva.py
+++ b/tests/ssspy/bss/test_iva.py
@@ -188,6 +188,7 @@ def test_grad_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -253,6 +254,7 @@ def test_natural_grad_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -329,6 +331,7 @@ def test_fast_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -387,6 +390,7 @@ def test_faster_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -499,6 +503,7 @@ def test_aux_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -534,6 +539,7 @@ def test_grad_laplace_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -569,6 +575,7 @@ def test_grad_gauss_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -606,6 +613,7 @@ def test_natural_grad_laplace_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -641,6 +649,7 @@ def test_natural_grad_gauss_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -685,6 +694,7 @@ def test_aux_laplace_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)
 
@@ -727,5 +737,6 @@ def test_aux_gauss_iva(
     spectrogram_est = iva(spectrogram_mix, n_iter=n_iter)
 
     assert spectrogram_mix.shape == spectrogram_est.shape
+    assert type(iva.loss[-1]) is float
 
     print(iva)


### PR DESCRIPTION
## Summary
So far, we've returned `np.ndarray` as loss despite the fact that the type annotation is `float`.
I fixed this inconsistency.

I also fixed the contrast function in `AuxLaplaceFDICA`.