### PR TITLE
Add sphinx-autobuild

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
 docs = [
     "sphinx",
     "sphinx-autodoc-typehints",
+    "sphinx-autobuild",
     "furo",
 ]
 tests = [


### PR DESCRIPTION
## Summary
I added `sphinx-autobuild` to dependencies.
You can automatically build the docs by running
```sh
sphinx-autobuild docs docs/_build/html
```