### PR TITLE
Wrapper of sample data loader

### DIFF
--- a/tests/dummy/utils/dataset/__init__.py
+++ b/tests/dummy/utils/dataset/__init__.py
@@ -41,6 +41,7 @@ def download_sample_speech_data(
             max_duration=max_duration,
             conv=conv,
         )
+        os.makedirs(cache_dir, exist_ok=True)
         np.savez(npz_path, waveform_src_img=waveform_src_img, sample_rate=sample_rate)
 
     return waveform_src_img, sample_rate

--- a/tests/dummy/utils/dataset/__init__.py
+++ b/tests/dummy/utils/dataset/__init__.py
@@ -16,12 +16,15 @@ def download_sample_speech_data(
     conv: bool = True,
     cache_dir: str = ".tests/.data/.cache",
 ) -> Tuple[np.ndarray, int]:
-    hash = hashlib.sha256(sisec2010_root).hexdigest()
-    hash += hashlib.sha256(mird_root).hexdigest()
-    hash += hashlib.sha256(str(n_sources)).hexdigest()
-    hash += hashlib.sha256(sisec2010_tag).hexdigest()
-    hash += hashlib.sha256(str(max_duration)).hexdigest()
-    hash += hashlib.sha256(str(conv)).hexdigest()
+    hash = hashlib.sha256(sisec2010_root.encode("utf-8")).hexdigest()
+    hash += hashlib.sha256(mird_root.encode("utf-8")).hexdigest()
+    hash += hashlib.sha256(str(n_sources).encode("utf-8")).hexdigest()
+    hash += hashlib.sha256(sisec2010_tag.encode("utf-8")).hexdigest()
+    hash += hashlib.sha256(str(max_duration).encode("utf-8")).hexdigest()
+    hash += hashlib.sha256(str(conv).encode("utf-8")).hexdigest()
+
+    # because concatenated hash is too long
+    hash = hashlib.sha256(hash.encode("utf-8")).hexdigest()
 
     npz_path = os.path.join(cache_dir, "{}.npz".format(hash))
 

--- a/tests/dummy/utils/dataset/__init__.py
+++ b/tests/dummy/utils/dataset/__init__.py
@@ -1,0 +1,43 @@
+import hashlib
+import os
+from typing import Tuple
+
+import numpy as np
+
+from ssspy.utils.dataset import download_sample_speech_data as _download
+
+
+def download_sample_speech_data(
+    sisec2010_root: str = "./tests/.data/SiSEC2010",
+    mird_root: str = "./tests/.data/MIRD",
+    n_sources: int = 3,
+    sisec2010_tag: str = "dev1_female3",
+    max_duration: float = 10,
+    conv: bool = True,
+    cache_dir: str = ".tests/.data/.cache",
+) -> Tuple[np.ndarray, int]:
+    hash = hashlib.sha256(sisec2010_root).hexdigest()
+    hash += hashlib.sha256(mird_root).hexdigest()
+    hash += hashlib.sha256(str(n_sources)).hexdigest()
+    hash += hashlib.sha256(sisec2010_tag).hexdigest()
+    hash += hashlib.sha256(str(max_duration)).hexdigest()
+    hash += hashlib.sha256(str(conv)).hexdigest()
+
+    npz_path = os.path.join(cache_dir, "{}.npz".format(hash))
+
+    if os.path.exists(npz_path):
+        npz = np.load(npz_path)
+        waveform_src_img, sample_rate = npz["waveform_src_img"], npz["sample_rate"]
+        sample_rate = sample_rate.item()
+    else:
+        waveform_src_img, sample_rate = _download(
+            sisec2010_root=sisec2010_root,
+            mird_root=mird_root,
+            n_sources=n_sources,
+            sisec2010_tag=sisec2010_tag,
+            max_duration=max_duration,
+            conv=conv,
+        )
+        np.savez(npz_path, waveform_src_img=waveform_src_img, sample_rate=sample_rate)
+
+    return waveform_src_img, sample_rate

--- a/tests/ssspy/bss/test_fdica.py
+++ b/tests/ssspy/bss/test_fdica.py
@@ -15,12 +15,12 @@ from ssspy.bss.fdica import (
     NaturalGradFDICA,
     NaturalGradLaplaceFDICA,
 )
-from ssspy.utils.dataset import download_sample_speech_data
 
 ssspy_tests_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.append(ssspy_tests_dir)
 
 from dummy.callback import DummyCallback, dummy_function  # noqa: E402
+from dummy.utils.dataset import download_sample_speech_data  # noqa: E402
 
 max_duration = 0.5
 n_fft = 512
@@ -78,8 +78,6 @@ def test_grad_fdica(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -123,8 +121,6 @@ def test_natural_grad_fdica(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -168,8 +164,6 @@ def test_aux_fdica(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -216,8 +210,6 @@ def test_grad_laplace_fdica(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -255,8 +247,6 @@ def test_natural_grad_laplace_fdica(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -293,8 +283,6 @@ def test_aux_laplace_fdica(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,

--- a/tests/ssspy/bss/test_ica.py
+++ b/tests/ssspy/bss/test_ica.py
@@ -13,12 +13,12 @@ from ssspy.bss.ica import (
     NaturalGradICA,
     NaturalGradLaplaceICA,
 )
-from ssspy.utils.dataset import download_sample_speech_data
 
 ssspy_tests_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.append(ssspy_tests_dir)
 
 from dummy.callback import DummyCallback, dummy_function  # noqa: E402
+from dummy.utils.dataset import download_sample_speech_data  # noqa: E402
 
 max_duration = 0.5
 n_iter = 3
@@ -65,8 +65,6 @@ def test_grad_ica(
     reset_kwargs: Dict[Any, Any],
 ):
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -101,8 +99,6 @@ def test_natural_grad_ica(
     reset_kwargs: Dict[Any, Any],
 ):
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -137,8 +133,6 @@ def test_grad_laplace_ica(
     reset_kwargs: Dict[Any, Any],
 ):
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -165,8 +159,6 @@ def test_natural_grad_laplace_ica(
     reset_kwargs: Dict[Any, Any],
 ):
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -191,8 +183,6 @@ def test_fast_ica(
     reset_kwargs: Dict[Any, Any],
 ):
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,

--- a/tests/ssspy/bss/test_ilrma.py
+++ b/tests/ssspy/bss/test_ilrma.py
@@ -7,20 +7,18 @@ import pytest
 import scipy.signal as ss
 
 from ssspy.bss.ilrma import GGDILRMA, TILRMA, GaussILRMA, ILRMAbase
-from ssspy.utils.dataset import download_sample_speech_data
 
 ssspy_tests_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.append(ssspy_tests_dir)
 
 from dummy.callback import DummyCallback, dummy_function  # noqa: E402
+from dummy.utils.dataset import download_sample_speech_data  # noqa: E402
 
 max_duration = 0.5
 n_fft = 512
 hop_length = 256
 n_bins = n_fft // 2 + 1
 n_iter = 3
-sisec2010_root = "./tests/.data/SiSEC2010"
-mird_root = "./tests/.data/MIRD"
 rng = np.random.default_rng(42)
 
 parameters_dof = [1, 100]
@@ -111,8 +109,6 @@ def test_gauss_ilrma_latent(
         raise ValueError("n_sources should be less than 5.")
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root=sisec2010_root,
-        mird_root=mird_root,
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,
@@ -168,8 +164,6 @@ def test_gauss_ilrma_wo_latent(
         raise ValueError("n_sources should be less than 5.")
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root=sisec2010_root,
-        mird_root=mird_root,
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,
@@ -227,8 +221,6 @@ def test_t_ilrma_latent(
         raise ValueError("n_sources should be less than 5.")
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root=sisec2010_root,
-        mird_root=mird_root,
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,
@@ -287,8 +279,6 @@ def test_t_ilrma_wo_latent(
         raise ValueError("n_sources should be less than 5.")
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root=sisec2010_root,
-        mird_root=mird_root,
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,
@@ -347,8 +337,6 @@ def test_ggd_ilrma_latent(
         raise ValueError("n_sources should be less than 5.")
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root=sisec2010_root,
-        mird_root=mird_root,
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,
@@ -407,8 +395,6 @@ def test_ggd_ilrma_wo_latent(
         raise ValueError("n_sources should be less than 5.")
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root=sisec2010_root,
-        mird_root=mird_root,
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,

--- a/tests/ssspy/bss/test_iva.py
+++ b/tests/ssspy/bss/test_iva.py
@@ -23,12 +23,12 @@ from ssspy.bss.iva import (
     NaturalGradIVA,
     NaturalGradLaplaceIVA,
 )
-from ssspy.utils.dataset import download_sample_speech_data
 
 ssspy_tests_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 sys.path.append(ssspy_tests_dir)
 
 from dummy.callback import DummyCallback, dummy_function  # noqa: E402
+from dummy.utils.dataset import download_sample_speech_data  # noqa: E402
 
 max_duration = 0.5
 n_fft = 512
@@ -148,8 +148,6 @@ def test_grad_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -214,8 +212,6 @@ def test_natural_grad_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -277,8 +273,6 @@ def test_fast_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,
@@ -354,8 +348,6 @@ def test_faster_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,
@@ -461,8 +453,6 @@ def test_aux_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,
@@ -529,8 +519,6 @@ def test_grad_laplace_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -565,8 +553,6 @@ def test_grad_gauss_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -603,8 +589,6 @@ def test_natural_grad_laplace_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -639,8 +623,6 @@ def test_natural_grad_gauss_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag="dev1_female3",
         max_duration=max_duration,
@@ -680,8 +662,6 @@ def test_aux_laplace_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,
@@ -723,8 +703,6 @@ def test_aux_gauss_iva(
     np.random.seed(111)
 
     waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
         n_sources=n_sources,
         sisec2010_tag=sisec2010_tag,
         max_duration=max_duration,


### PR DESCRIPTION
## Summary
To speed up tests, a wrapper of the sample data loader is implemented.
In this wrapper, we don't have to compute convolution multiple times.