### PR TITLE
Change superclass of NaturalGradLaplaceFDICA

### DIFF
--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -1257,7 +1257,7 @@ class GradLaplaceFDICA(GradFDICA):
         return s.format(**self.__dict__)
 
 
-class NaturalGradLaplaceFDICA(GradFDICA):
+class NaturalGradLaplaceFDICA(NaturalGradFDICA):
     r"""Frequency-domain independent component analysis (FDICA) \
     using the natural gradient descent on a Laplace distribution.
 


### PR DESCRIPTION
## Summary
Change superclass of `NaturalGradLaplaceFDICA` into `NaturalGradFDICA`.
Fix #186.