### PR TITLE
Principal square root of a positive semidefinite matrix

### DIFF
--- a/ssspy/linalg/__init__.py
+++ b/ssspy/linalg/__init__.py
@@ -1,5 +1,5 @@
 from .eigh import eigh, eigh2
 from .inv import inv2
-from .sqrtm import sqrtmh
+from .sqrtm import invsqrtmh, sqrtmh
 
-__all__ = ["inv2", "eigh", "eigh2", "sqrtmh"]
+__all__ = ["inv2", "eigh", "eigh2", "sqrtmh", "invsqrtmh"]

--- a/ssspy/linalg/__init__.py
+++ b/ssspy/linalg/__init__.py
@@ -1,4 +1,5 @@
 from .eigh import eigh, eigh2
 from .inv import inv2
+from .sqrtm import sqrtmh
 
-__all__ = ["inv2", "eigh", "eigh2"]
+__all__ = ["inv2", "eigh", "eigh2", "sqrtmh"]

--- a/ssspy/linalg/sqrtm.py
+++ b/ssspy/linalg/sqrtm.py
@@ -1,0 +1,25 @@
+import numpy as np
+
+from .eigh import eigh
+
+
+def sqrtmh(X: np.ndarray) -> np.ndarray:
+    r"""Compute square root of a complex Hermitian (conjugate symmetric) or a real symmetric matrix.
+
+    Args:
+        X (numpy.ndarray):
+            A complex Hermitian matrix with shape of (\*, n_channels, n_channels).
+
+    Returns:
+        numpy.ndarray of square root. The shape is same as that of input.
+    """
+    Lamb, P = eigh(X)
+
+    P_Hermite = P.swapaxes(-2, -1)
+
+    if np.iscomplexobj(X):
+        P_Hermite = P_Hermite.conj()
+
+    Lamb = np.sqrt(Lamb)[..., np.newaxis] * np.eye(Lamb.shape[-1])
+
+    return P @ Lamb @ P_Hermite

--- a/ssspy/linalg/sqrtm.py
+++ b/ssspy/linalg/sqrtm.py
@@ -1,14 +1,16 @@
+from typing import Callable, Optional
+
 import numpy as np
 
 from .eigh import eigh
 
 
 def sqrtmh(X: np.ndarray) -> np.ndarray:
-    r"""Compute square root of a complex Hermitian (conjugate symmetric) or a real symmetric matrix.
+    r"""Compute square root of a positive semidefinite Hermitian or symmetric matrix.
 
     Args:
         X (numpy.ndarray):
-            A complex Hermitian matrix with shape of (\*, n_channels, n_channels).
+            A complex Hermitian or symmetric matrix with shape of (\*, n_channels, n_channels).
 
     Returns:
         numpy.ndarray of square root. The shape is same as that of input.
@@ -21,5 +23,38 @@ def sqrtmh(X: np.ndarray) -> np.ndarray:
         P_Hermite = P_Hermite.conj()
 
     Lamb = np.sqrt(Lamb)[..., np.newaxis] * np.eye(Lamb.shape[-1])
+
+    return P @ Lamb @ P_Hermite
+
+
+def invsqrtmh(
+    X: np.ndarray,
+    flooring_fn: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+) -> np.ndarray:
+    r"""Compute inversion of square root for a positive definite Hermitian or symmetric matrix.
+
+    Args:
+        X (numpy.ndarray):
+            A complex Hermitian matrix with shape of (\*, n_channels, n_channels).
+
+    Returns:
+        numpy.ndarray of inversion of square root. The shape is same as that of input.
+    """
+
+    def _identity(x):
+        return x
+
+    if flooring_fn is None:
+        flooring_fn = _identity
+
+    Lamb, P = eigh(X)
+
+    P_Hermite = P.swapaxes(-2, -1)
+
+    if np.iscomplexobj(X):
+        P_Hermite = P_Hermite.conj()
+
+    Lamb = 1 / flooring_fn(np.sqrt(Lamb))
+    Lamb = Lamb[..., np.newaxis] * np.eye(Lamb.shape[-1])
 
     return P @ Lamb @ P_Hermite

--- a/ssspy/linalg/sqrtm.py
+++ b/ssspy/linalg/sqrtm.py
@@ -36,6 +36,10 @@ def invsqrtmh(
     Args:
         X (numpy.ndarray):
             A complex Hermitian matrix with shape of (\*, n_channels, n_channels).
+        flooring_fn (callable, optional):
+            A flooring function for numerical stability.
+            This function is expected to receive and return the same shape as that of X.
+            By default, the identity function (``lambda x: x``) is used.
 
     Returns:
         numpy.ndarray of inversion of square root. The shape is same as that of input.

--- a/tests/ssspy/linalg/test_sqrtm.py
+++ b/tests/ssspy/linalg/test_sqrtm.py
@@ -1,12 +1,13 @@
 import numpy as np
 import pytest
 
-from ssspy.linalg import sqrtmh
+from ssspy.linalg import invsqrtmh, sqrtmh
 
 parameters_sources = [2]
 parameters_channels = [3, 4]
 parameters_frames = [32]
 parameters_is_complex = [True, False]
+parameters_is_flooring = [True, False]
 
 
 @pytest.mark.parametrize("n_sources", parameters_sources)
@@ -26,5 +27,34 @@ def test_sqrtmh(n_sources: int, n_channels: int, n_frames: int, is_complex: bool
         X = np.mean(x[:, :, np.newaxis, :] * x[:, np.newaxis, :, :], axis=-1)
 
     X_sqrt = sqrtmh(X)
+
+    assert np.allclose(X, X_sqrt @ X_sqrt)
+
+
+@pytest.mark.parametrize("n_sources", parameters_sources)
+@pytest.mark.parametrize("n_channels", parameters_channels)
+@pytest.mark.parametrize("n_frames", parameters_frames)
+@pytest.mark.parametrize("is_complex", parameters_is_complex)
+@pytest.mark.parametrize("is_flooring", parameters_is_flooring)
+def test_invsqrtmh(
+    n_sources: int, n_channels: int, n_frames: int, is_complex: bool, is_flooring: bool
+):
+    rng = np.random.default_rng(0)
+
+    shape = (n_sources, n_channels, n_frames)
+
+    if is_complex:
+        x = rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+        X = np.mean(x[:, :, np.newaxis, :] * x[:, np.newaxis, :, :].conj(), axis=-1)
+    else:
+        x = rng.standard_normal(shape)
+        X = np.mean(x[:, :, np.newaxis, :] * x[:, np.newaxis, :, :], axis=-1)
+
+    if is_flooring:
+        X_invsqrt = invsqrtmh(X, flooring_fn=lambda x: np.maximum(x, 1e-12))
+    else:
+        X_invsqrt = invsqrtmh(X)
+
+    X_sqrt = np.linalg.inv(X_invsqrt)
 
     assert np.allclose(X, X_sqrt @ X_sqrt)

--- a/tests/ssspy/linalg/test_sqrtm.py
+++ b/tests/ssspy/linalg/test_sqrtm.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from ssspy.linalg import sqrtmh
+
+parameters_sources = [2]
+parameters_channels = [3, 4]
+parameters_frames = [32]
+parameters_is_complex = [True, False]
+
+
+@pytest.mark.parametrize("n_sources", parameters_sources)
+@pytest.mark.parametrize("n_channels", parameters_channels)
+@pytest.mark.parametrize("n_frames", parameters_frames)
+@pytest.mark.parametrize("is_complex", parameters_is_complex)
+def test_sqrtmh(n_sources: int, n_channels: int, n_frames: int, is_complex: bool):
+    rng = np.random.default_rng(0)
+
+    shape = (n_sources, n_channels, n_frames)
+
+    if is_complex:
+        x = rng.standard_normal(shape) + 1j * rng.standard_normal(shape)
+        X = np.mean(x[:, :, np.newaxis, :] * x[:, np.newaxis, :, :].conj(), axis=-1)
+    else:
+        x = rng.standard_normal(shape)
+        X = np.mean(x[:, :, np.newaxis, :] * x[:, np.newaxis, :, :], axis=-1)
+
+    X_sqrt = sqrtmh(X)
+
+    assert np.allclose(X, X_sqrt @ X_sqrt)


### PR DESCRIPTION
## Summary
Implemented
- principal square root of a positive semidefinite matrix.
- inversion of the principal square root of a positive definite matrix.
    - for positive **semi**definite matrix, we can apply flooring operation.

This will be useful for the implementation of IPSDTA.

ref #33 

```python3
import ssspy

# A: positive semidefinite matrix
A_sqrt = ssspy.linalg.sqrtmh(A)
A_invsqrt = ssspy.linalg.invsqrtmh(A)
```