### PR TITLE
Change default epsilon

### DIFF
--- a/ssspy/bss/_flooring.py
+++ b/ssspy/bss/_flooring.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-EPS = 1e-12
+EPS = 1e-10
 
 
 def identity(input: np.ndarray) -> np.ndarray:

--- a/ssspy/bss/_solve_permutation.py
+++ b/ssspy/bss/_solve_permutation.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from ._flooring import identity, max_flooring
 
-EPS = 1e-12
+EPS = 1e-10
 
 
 def correlation_based_permutation_solver(

--- a/ssspy/bss/_update_spatial_model.py
+++ b/ssspy/bss/_update_spatial_model.py
@@ -7,7 +7,7 @@ from ..linalg import eigh2, inv2
 from ._flooring import identity, max_flooring
 from ._select_pair import sequential_pair_selector
 
-EPS = 1e-12
+EPS = 1e-10
 
 
 def update_by_ip1(

--- a/ssspy/bss/fdica.py
+++ b/ssspy/bss/fdica.py
@@ -25,7 +25,7 @@ __all__ = [
 ]
 
 spatial_algorithms = ["IP", "IP1", "IP2"]
-EPS = 1e-12
+EPS = 1e-10
 
 
 class FDICAbase(IterativeMethodBase):
@@ -42,7 +42,7 @@ class FDICAbase(IterativeMethodBase):
             and return (n_channels, n_bins, n_frames).
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``partial(max_flooring, eps=1e-12)``.
+            Default: ``partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -302,7 +302,7 @@ class GradFDICAbase(FDICAbase):
             and return (n_channels, n_bins, n_frames).
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``partial(max_flooring, eps=1e-12)``.
+            Default: ``partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -435,7 +435,7 @@ class GradFDICA(GradFDICAbase):
             and return (n_channels, n_bins, n_frames).
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``partial(max_flooring, eps=1e-12)``.
+            Default: ``partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -465,7 +465,7 @@ class GradFDICA(GradFDICAbase):
             ...     return 2 * np.abs(y)
 
             >>> def score_fn(y):
-            ...     denom = np.maximum(np.abs(y), 1e-12)
+            ...     denom = np.maximum(np.abs(y), 1e-10)
             ...     return y / denom
 
             >>> n_channels, n_bins, n_frames = 2, 2049, 128
@@ -490,7 +490,7 @@ class GradFDICA(GradFDICAbase):
             ...     return 2 * np.abs(y)
 
             >>> def score_fn(y):
-            ...     denom = np.maximum(np.abs(y), 1e-12)
+            ...     denom = np.maximum(np.abs(y), 1e-10)
             ...     return y / denom
 
             >>> n_channels, n_bins, n_frames = 2, 2049, 128
@@ -630,7 +630,7 @@ class NaturalGradFDICA(GradFDICAbase):
             and return (n_channels, n_bins, n_frames).
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``partial(max_flooring, eps=1e-12)``.
+            Default: ``partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -660,7 +660,7 @@ class NaturalGradFDICA(GradFDICAbase):
             ...     return 2 * np.abs(y)
 
             >>> def score_fn(y):
-            ...     denom = np.maximum(np.abs(y), 1e-12)
+            ...     denom = np.maximum(np.abs(y), 1e-10)
             ...     return y / denom
 
             >>> n_channels, n_bins, n_frames = 2, 2049, 128
@@ -685,7 +685,7 @@ class NaturalGradFDICA(GradFDICAbase):
             ...     return 2 * np.abs(y)
 
             >>> def score_fn(y):
-            ...     denom = np.maximum(np.abs(y), 1e-12)
+            ...     denom = np.maximum(np.abs(y), 1e-10)
             ...     return y / denom
 
             >>> n_channels, n_bins, n_frames = 2, 2049, 128
@@ -824,7 +824,7 @@ class AuxFDICA(FDICAbase):
             and return (n_channels, n_bins, n_frames).
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``partial(max_flooring, eps=1e-12)``.
+            Default: ``partial(max_flooring, eps=1e-10)``.
         pair_selector (callable, optional):
             Selector to choose updaing pair in ``IP2`` and ``ISS2``.
             If ``None`` is given, ``partial(sequential_pair_selector, sort=True)`` is used.
@@ -1181,7 +1181,7 @@ class GradLaplaceFDICA(GradFDICA):
             and return (n_channels, n_bins, n_frames).
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``partial(max_flooring, eps=1e-12)``.
+            Default: ``partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -1319,7 +1319,7 @@ class NaturalGradLaplaceFDICA(NaturalGradFDICA):
             and return (n_channels, n_bins, n_frames).
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``partial(max_flooring, eps=1e-12)``.
+            Default: ``partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -1461,7 +1461,7 @@ class AuxLaplaceFDICA(AuxFDICA):
             and return (n_channels, n_bins, n_frames).
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``partial(max_flooring, eps=1e-12)``.
+            Default: ``partial(max_flooring, eps=1e-10)``.
         pair_selector (callable, optional):
             Selector to choose updaing pair in ``IP2`` and ``ISS2``.
             If ``None`` is given, ``partial(sequential_pair_selector, sort=True)`` is used.

--- a/ssspy/bss/ilrma.py
+++ b/ssspy/bss/ilrma.py
@@ -18,7 +18,7 @@ from .base import IterativeMethodBase
 __all__ = ["GaussILRMA", "TILRMA", "GGDILRMA"]
 
 spatial_algorithms = ["IP", "IP1", "IP2", "ISS", "ISS1", "ISS2"]
-EPS = 1e-12
+EPS = 1e-10
 
 
 class ILRMAbase(IterativeMethodBase):
@@ -34,7 +34,7 @@ class ILRMAbase(IterativeMethodBase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -554,7 +554,7 @@ class GaussILRMA(ILRMAbase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         pair_selector (callable, optional):
             Selector to choose updaing pair in ``IP2`` and ``ISS2``.
             If ``None`` is given, ``sequential_pair_selector`` is used.
@@ -1402,7 +1402,7 @@ class TILRMA(ILRMAbase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         pair_selector (callable, optional):
             Selector to choose updaing pair in ``IP2`` and ``ISS2``.
             If ``None`` is given, ``sequential_pair_selector`` is used.
@@ -2321,7 +2321,7 @@ class GGDILRMA(ILRMAbase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         pair_selector (callable, optional):
             Selector to choose updaing pair in ``IP2`` and ``ISS2``.
             If ``None`` is given, ``sequential_pair_selector`` is used.

--- a/ssspy/bss/iva.py
+++ b/ssspy/bss/iva.py
@@ -36,7 +36,7 @@ __all__ = [
 ]
 
 spatial_algorithms = ["IP", "IP1", "IP2", "ISS", "ISS1", "ISS2"]
-EPS = 1e-12
+EPS = 1e-10
 
 
 class IVAbase(IterativeMethodBase):
@@ -48,7 +48,7 @@ class IVAbase(IterativeMethodBase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -294,7 +294,7 @@ class GradIVAbase(IVAbase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -409,7 +409,7 @@ class FastIVAbase(IVAbase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -654,7 +654,7 @@ class GradIVA(GradIVAbase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -682,7 +682,7 @@ class GradIVA(GradIVAbase):
 
             >>> def score_fn(y):
             ...     norm = np.linalg.norm(y, axis=1, keepdims=True)
-            ...     return y / np.maximum(norm, 1e-12)
+            ...     return y / np.maximum(norm, 1e-10)
 
             >>> n_channels, n_bins, n_frames = 2, 2049, 128
             >>> spectrogram_mix = np.random.randn(n_channels, n_bins, n_frames) \
@@ -706,7 +706,7 @@ class GradIVA(GradIVAbase):
 
             >>> def score_fn(y):
             ...     norm = np.linalg.norm(y, axis=1, keepdims=True)
-            ...     return y / np.maximum(norm, 1e-12)
+            ...     return y / np.maximum(norm, 1e-10)
 
             >>> n_channels, n_bins, n_frames = 2, 2049, 128
             >>> spectrogram_mix = np.random.randn(n_channels, n_bins, n_frames) \
@@ -831,7 +831,7 @@ class NaturalGradIVA(GradIVAbase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -859,7 +859,7 @@ class NaturalGradIVA(GradIVAbase):
 
             >>> def score_fn(y):
             ...     norm = np.linalg.norm(y, axis=1, keepdims=True)
-            ...     return y / np.maximum(norm, 1e-12)
+            ...     return y / np.maximum(norm, 1e-10)
 
             >>> n_channels, n_bins, n_frames = 2, 2049, 128
             >>> spectrogram_mix = np.random.randn(n_channels, n_bins, n_frames) \
@@ -883,7 +883,7 @@ class NaturalGradIVA(GradIVAbase):
 
             >>> def score_fn(y):
             ...     norm = np.linalg.norm(y, axis=1, keepdims=True)
-            ...     return y / np.maximum(norm, 1e-12)
+            ...     return y / np.maximum(norm, 1e-10)
 
             >>> n_channels, n_bins, n_frames = 2, 2049, 128
             >>> spectrogram_mix = np.random.randn(n_channels, n_bins, n_frames) \
@@ -1003,7 +1003,7 @@ class FastIVA(FastIVAbase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -1204,7 +1204,7 @@ class FasterIVA(FastIVAbase):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -1964,7 +1964,7 @@ class GradLaplaceIVA(GradIVA):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -2130,7 +2130,7 @@ class GradGaussIVA(GradIVA):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -2280,7 +2280,7 @@ class NaturalGradLaplaceIVA(NaturalGradIVA):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.
@@ -2449,7 +2449,7 @@ class NaturalGradGaussIVA(NaturalGradIVA):
             This function is expected to return the same shape tensor as the input.
             If you explicitly set ``flooring_fn=None``,
             the identity function (``lambda x: x``) is used.
-            Default: ``functools.partial(max_flooring, eps=1e-12)``.
+            Default: ``functools.partial(max_flooring, eps=1e-10)``.
         callbacks (callable or list[callable], optional):
             Callback functions. Each function is called before separation and at each iteration.
             Default: ``None``.


### PR DESCRIPTION
## Summary
I previously set `EPS=1e-12` instead of `EPS=1e-10` to avoid violating the nonincrease of values of the cost function in ILRMA.
However, this tiny value often occurs `LinalgError`, so I change it back to `1e-10`.