### PR TITLE
Enable to specify reverberation time of MIRD

### DIFF
--- a/ssspy/utils/dataset/__init__.py
+++ b/ssspy/utils/dataset/__init__.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -16,6 +16,7 @@ def download_sample_speech_data(
     n_sources: int = 3,
     sisec2010_tag: str = "dev1_female3",
     max_duration: float = 10,
+    reverb_duration: Optional[float] = 0.16,
     conv: bool = True,
 ) -> Tuple[np.ndarray, int]:
     r"""Download sample speech data to test sepration methods.
@@ -31,10 +32,13 @@ def download_sample_speech_data(
             Number of sources included in sample data.
         sisec2010_tag (str):
             Tag of SiSEC 2010 data.
-            Choose "dev1_female3" or "dev1_female4".
-            Default:"dev1_female3".
+            Choose ``dev1_female3`` or ``dev1_female4``.
+            Default: ``dev1_female3``.
         max_duration (float):
             Maximum duration. Default: ``160000``.
+        reverb_duration (float):
+            Duration of reverberation in MIRD.
+            Choose ``0.16`` or ``0.36``. Default: ``0.16``.
         conv (bool):
             Convolutive mixture or not. Defalt: ``True``.
 
@@ -54,7 +58,9 @@ def download_sample_speech_data(
     assert sample_rate == sisec2010_npz["sample_rate"].item(), "Invalid sampling rate is detected."
 
     if conv:
-        mird_npz_path = download_mird(root=mird_root, n_sources=n_sources)
+        mird_npz_path = download_mird(
+            root=mird_root, n_sources=n_sources, reverb_duration=reverb_duration
+        )
         mird_npz = np.load(mird_npz_path)
 
         assert sample_rate == mird_npz["sample_rate"].item(), "Invalid sampling rate is detected."

--- a/ssspy/utils/dataset/__init__.py
+++ b/ssspy/utils/dataset/__init__.py
@@ -38,7 +38,7 @@ def download_sample_speech_data(
             Maximum duration. Default: ``160000``.
         reverb_duration (float):
             Duration of reverberation in MIRD.
-            Choose ``0.16`` or ``0.36``. Default: ``0.16``.
+            Choose ``0.16``, ``0.36``, ``0.61``. Default: ``0.16``.
         conv (bool):
             Convolutive mixture or not. Defalt: ``True``.
 

--- a/ssspy/utils/dataset/__init__.py
+++ b/ssspy/utils/dataset/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Tuple
 
 import numpy as np
 
@@ -16,7 +16,7 @@ def download_sample_speech_data(
     n_sources: int = 3,
     sisec2010_tag: str = "dev1_female3",
     max_duration: float = 10,
-    reverb_duration: Optional[float] = 0.16,
+    reverb_duration: float = 0.16,
     conv: bool = True,
 ) -> Tuple[np.ndarray, int]:
     r"""Download sample speech data to test sepration methods.

--- a/ssspy/utils/dataset/mird.py
+++ b/ssspy/utils/dataset/mird.py
@@ -4,7 +4,7 @@ import urllib.request
 
 import numpy as np
 
-reverb_durations = [0.16, 0.36]
+reverb_durations = [0.16, 0.36, 0.61]
 
 
 def download(root: str = ".data/MIRD", n_sources: int = 3, reverb_duration: float = 0.16) -> str:

--- a/ssspy/utils/dataset/mird.py
+++ b/ssspy/utils/dataset/mird.py
@@ -4,12 +4,19 @@ import urllib.request
 
 import numpy as np
 
+reverb_durations = [0.16, 0.36]
 
-def download(root: str = ".data/MIRD", n_sources: int = 3) -> str:
+
+def download(root: str = ".data/MIRD", n_sources: int = 3, reverb_duration: float = 0.16) -> str:
+    assert reverb_duration in reverb_durations, "reverb_duration should be chosen from {}.".format(
+        reverb_durations
+    )
+
     filename = (
         "Impulse_response_Acoustic_Lab_Bar-Ilan_University__"
-        "Reverberation_0.160s__3-3-3-8-3-3-3.zip"
+        "Reverberation_{reverb_duration:.3f}s__3-3-3-8-3-3-3.zip"
     )
+    filename = filename.format(reverb_duration=reverb_duration)
     url = (
         "https://www.iks.rwth-aachen.de/fileadmin/user_upload/downloads/"
         "forschung/tools-downloads/{filename}"
@@ -20,7 +27,7 @@ def download(root: str = ".data/MIRD", n_sources: int = 3) -> str:
     degrees = [30, 345, 0, 60, 315]
     channels = [3, 4, 2, 5, 1, 6, 0, 7]
     sample_rate = 16000
-    duration = 0.160
+    duration = reverb_duration
 
     degrees = degrees[:n_sources]
     channels = channels[:n_sources]
@@ -38,7 +45,9 @@ def download(root: str = ".data/MIRD", n_sources: int = 3) -> str:
     if not os.path.exists(zip_path):
         urllib.request.urlretrieve(url, zip_path)
 
-    if not os.path.exists(os.path.join(root, template_rir_name.format(0.16, 0))):
+    rir_path = os.path.join(root, template_rir_name.format(reverb_duration, 0))
+
+    if not os.path.exists(rir_path):
         shutil.unpack_archive(zip_path, root)
 
     npz_path = os.path.join(root, "MIRD-{}ch.npz".format(n_channels))


### PR DESCRIPTION
## Summary
By this PR, you can specify the reverberation time of MIRD.
You can choose `0.16`, `0.36`, or `0.61`.

## Notes
MIRD: https://www.iks.rwth-aachen.de/en/research/tools-downloads/databases/multi-channel-impulse-response-database/