### PR TITLE
Consider corner case of cubic polynomial

### DIFF
--- a/ssspy/linalg/polynomial.py
+++ b/ssspy/linalg/polynomial.py
@@ -80,10 +80,16 @@ def _find_cubic_roots(P: np.ndarray, Q: np.ndarray) -> np.ndarray:
     discriminant = (Q / 2) ** 2 + (P / 3) ** 3
 
     U = cbrt(-Q / 2 + np.sqrt(discriminant))
+    # U = 0, when P = 0.
+    is_singular = U == 0
+    U = np.where(is_singular, 1, U)
     V = -P / (3 * U)
 
     X1 = U + V
+    X1 = np.where(is_singular, cbrt(-Q), X1)
     X2 = U * omega + V * omega_conj
+    X2 = np.where(is_singular, X1 * omega, X2)
     X3 = U * omega_conj + V * omega
+    X3 = np.where(is_singular, X1 * omega_conj, X3)
 
     return np.stack([X1, X2, X3], axis=0)

--- a/ssspy/linalg/polynomial.py
+++ b/ssspy/linalg/polynomial.py
@@ -81,7 +81,7 @@ def _find_cubic_roots(P: np.ndarray, Q: np.ndarray) -> np.ndarray:
 
     U = cbrt(-Q / 2 + np.sqrt(discriminant))
     # U = 0, when P = 0.
-    is_singular = U == 0
+    is_singular = P == 0
     U = np.where(is_singular, 1, U)
     V = -P / (3 * U)
 

--- a/tests/ssspy/linalg/test_polynomial.py
+++ b/tests/ssspy/linalg/test_polynomial.py
@@ -35,3 +35,12 @@ def test_solve_cubic():
     Y = A * X**3 + B * X**2 + C * X + D
 
     assert np.allclose(Y, 0)
+
+    # corner case
+    A = np.zeros_like(C)
+    B = np.zeros_like(C)
+
+    X = solve_cubic(A, B, C)
+    Y = X**3 + A * X**2 + B * X + C
+
+    assert np.allclose(Y, 0)

--- a/tests/ssspy/linalg/test_polynomial.py
+++ b/tests/ssspy/linalg/test_polynomial.py
@@ -21,10 +21,36 @@ def test_solve_cubic():
 
     n_bins, n_channels = 3, 2
 
+    # real coefficients
     A = rng.standard_normal((n_bins, n_channels))
     B = rng.standard_normal((n_bins, n_channels))
     C = rng.standard_normal((n_bins, n_channels))
     D = rng.standard_normal((n_bins, n_channels))
+
+    X = solve_cubic(A, B, C)
+    Y = X**3 + A * X**2 + B * X + C
+
+    assert np.allclose(Y, 0)
+
+    X = solve_cubic(A, B, C, D)
+    Y = A * X**3 + B * X**2 + C * X + D
+
+    assert np.allclose(Y, 0)
+
+    # corner case
+    A = np.zeros_like(C)
+    B = np.zeros_like(C)
+
+    X = solve_cubic(A, B, C)
+    Y = X**3 + A * X**2 + B * X + C
+
+    assert np.allclose(Y, 0)
+
+    # complex coefficients
+    A = rng.standard_normal((n_bins, n_channels)) + 1j * rng.standard_normal((n_bins, n_channels))
+    B = rng.standard_normal((n_bins, n_channels)) + 1j * rng.standard_normal((n_bins, n_channels))
+    C = rng.standard_normal((n_bins, n_channels)) + 1j * rng.standard_normal((n_bins, n_channels))
+    D = rng.standard_normal((n_bins, n_channels)) + 1j * rng.standard_normal((n_bins, n_channels))
 
     X = solve_cubic(A, B, C)
     Y = X**3 + A * X**2 + B * X + C


### PR DESCRIPTION
## Summary

When the cubic polynomial has multiple roots, zero division happened by the previous implementation.
This PR fixes this error of cubic polynomial solver.

close #232
