### PR TITLE
Fix shape of varphi in tests of IVA

### DIFF
--- a/tests/ssspy/bss/test_update_spatial_model.py
+++ b/tests/ssspy/bss/test_update_spatial_model.py
@@ -54,7 +54,7 @@ def test_update_by_ip1(
 
     rng = np.random.default_rng(42)
 
-    varphi = 1 / rng.random((n_bins, n_frames))
+    varphi = 1 / rng.random((n_sources, n_frames))
     X = rng.standard_normal((n_channels, n_bins, n_frames))
     real = rng.standard_normal((n_bins, n_sources, n_sources))
     imag = rng.standard_normal((n_bins, n_sources, n_sources))
@@ -84,7 +84,7 @@ def test_update_by_ip2(
 
     rng = np.random.default_rng(42)
 
-    varphi = 1 / rng.random((n_bins, n_frames))
+    varphi = 1 / rng.random((n_sources, n_frames))
     X = rng.standard_normal((n_channels, n_bins, n_frames))
     real = rng.standard_normal((n_bins, n_sources, n_sources))
     imag = rng.standard_normal((n_bins, n_sources, n_sources))


### PR DESCRIPTION
## Summary
This PR fixes the shape of `varphi` in tests of IVA, which reduces the time of `pytest`.