### PR TITLE
End support of python=3.7

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "A Python toolkit for sound source separation."
 readme = "README.md"
 license = {file = "LICENSE"}
 urls = {url = "https://github.com/tky823/ssspy"}
-requires-python = ">=3.7, <4"
+requires-python = ">=3.8, <4"
 dependencies = [
     "numpy",
 ]


### PR DESCRIPTION
## Summary
Official support of python=3.7 is ended.
We also finish supporting this version.