### PR TITLE
Make PDSBSSBase inherit IterativeMethodBase

### DIFF
--- a/ssspy/bss/pdsbss.py
+++ b/ssspy/bss/pdsbss.py
@@ -9,11 +9,12 @@ from ..algorithm import (
     projection_back,
 )
 from ..linalg import prox
+from .base import IterativeMethodBase
 
 EPS = 1e-10
 
 
-class PDSBSSBase:
+class PDSBSSBase(IterativeMethodBase):
     r"""Base class of blind source separation \
     via proximal splitting algorithm [#yatabe2018determined]_.
 
@@ -54,6 +55,11 @@ class PDSBSSBase:
         record_loss: bool = True,
         reference_id: int = 0,
     ) -> None:
+        super().__init__(
+            callbacks=callbacks,
+            record_loss=record_loss,
+        )
+
         if penalty_fn is None:
             raise ValueError("Specify penalty function.")
         else:
@@ -72,13 +78,6 @@ class PDSBSSBase:
             self.prox_penalty
         ), "Length of penalty_fn and prox_penalty are different."
 
-        if callbacks is not None:
-            if callable(callbacks):
-                callbacks = [callbacks]
-            self.callbacks = callbacks
-        else:
-            self.callbacks = None
-
         self.input = None
         self.scale_restoration = scale_restoration
 
@@ -86,34 +85,6 @@ class PDSBSSBase:
             raise ValueError("Specify 'reference_id' if scale_restoration=True.")
         else:
             self.reference_id = reference_id
-
-        self.record_loss = record_loss
-
-        if self.record_loss:
-            self.loss = []
-        else:
-            self.loss = None
-
-    def __call__(self, input: np.ndarray, n_iter: int = 100, **kwargs) -> np.ndarray:
-        r"""Separate a frequency-domain multichannel signal.
-
-        Args:
-            input (numpy.ndarray):
-                Mixture signal in frequency-domain.
-                The shape is (n_channels, n_bins, n_frames).
-            n_iter (int):
-                Number of iterations of demixing filter updates.
-                Default: ``100``.
-
-        Returns:
-            numpy.ndarray of the separated signal in frequency-domain.
-            The shape is (n_channels, n_bins, n_frames).
-        """
-        self.input = input.copy()
-
-        self._reset(**kwargs)
-
-        raise NotImplementedError("Implement '__call__' method.")
 
     def __repr__(self) -> str:
         s = "PDSBSS("

--- a/ssspy/bss/pdsbss.py
+++ b/ssspy/bss/pdsbss.py
@@ -316,7 +316,7 @@ class PDSBSS(PDSBSSBase):
         self.mu1, self.mu2 = mu1, mu2
         self.alpha = alpha
 
-    def __call__(self, input, n_iter=100, **kwargs) -> np.ndarray:
+    def __call__(self, input, n_iter=100, initial_call: bool = True, **kwargs) -> np.ndarray:
         r"""Separate a frequency-domain multichannel signal.
 
         Args:
@@ -326,6 +326,9 @@ class PDSBSS(PDSBSSBase):
             n_iter (int):
                 Number of iterations of demixing filter updates.
                 Default: ``100``.
+            initial_call (bool):
+                If ``True``, perform callbacks (and computation of loss if necessary)
+                before iterations.
 
         Returns:
             numpy.ndarray of the separated signal in frequency-domain.
@@ -335,24 +338,8 @@ class PDSBSS(PDSBSSBase):
 
         self._reset(**kwargs)
 
-        if self.record_loss:
-            loss = self.compute_loss()
-            self.loss.append(loss)
-
-        if self.callbacks is not None:
-            for callback in self.callbacks:
-                callback(self)
-
-        for _ in range(n_iter):
-            self.update_once()
-
-            if self.record_loss:
-                loss = self.compute_loss()
-                self.loss.append(loss)
-
-            if self.callbacks is not None:
-                for callback in self.callbacks:
-                    callback(self)
+        # Call __call__ of PDSBSSBase's parent, i.e. __call__ of IterativeMethodBase
+        super(PDSBSSBase, self).__call__(n_iter=n_iter, initial_call=initial_call)
 
         if self.scale_restoration:
             self.restore_scale()

--- a/tests/package/bss/test_iterative_methods.py
+++ b/tests/package/bss/test_iterative_methods.py
@@ -1,0 +1,434 @@
+import numpy as np
+
+from ssspy.bss.base import IterativeMethodBase
+from ssspy.bss.cacgmm import CACGMM
+from ssspy.bss.fdica import (
+    AuxFDICA,
+    AuxLaplaceFDICA,
+    GradFDICA,
+    GradLaplaceFDICA,
+    NaturalGradFDICA,
+    NaturalGradLaplaceFDICA,
+)
+from ssspy.bss.ica import FastICA, GradICA, GradLaplaceICA, NaturalGradICA, NaturalGradLaplaceICA
+from ssspy.bss.ilrma import GGDILRMA, TILRMA, GaussILRMA
+from ssspy.bss.ipsdta import TIPSDTA, GaussIPSDTA
+from ssspy.bss.iva import (
+    PDSIVA,
+    AuxGaussIVA,
+    AuxIVA,
+    AuxLaplaceIVA,
+    FasterIVA,
+    FastIVA,
+    GradGaussIVA,
+    GradIVA,
+    GradLaplaceIVA,
+    NaturalGradGaussIVA,
+    NaturalGradIVA,
+    NaturalGradLaplaceIVA,
+)
+from ssspy.bss.mnmf import FastGaussMNMF, GaussMNMF
+from ssspy.bss.pdsbss import PDSBSS
+
+
+def test_grad_ica_inheritance() -> None:
+    def contrast_fn(x):
+        return np.log(1 + np.exp(x))
+
+    def score_fn(x):
+        return 1 / (1 + np.exp(-x))
+
+    ica = GradICA(contrast_fn=contrast_fn, score_fn=score_fn)
+
+    assert isinstance(ica, IterativeMethodBase)
+
+    ica = GradLaplaceICA()
+
+    assert isinstance(ica, IterativeMethodBase)
+
+
+def test_natural_grad_ica_inheritance() -> None:
+    def contrast_fn(x):
+        return np.log(1 + np.exp(x))
+
+    def score_fn(x):
+        return 1 / (1 + np.exp(-x))
+
+    ica = NaturalGradICA(contrast_fn=contrast_fn, score_fn=score_fn)
+
+    assert isinstance(ica, IterativeMethodBase)
+
+    ica = NaturalGradLaplaceICA()
+
+    assert isinstance(ica, IterativeMethodBase)
+
+
+def test_fast_ica_inheritance() -> None:
+    def contrast_fn(x):
+        return np.log(1 + np.exp(x))
+
+    def score_fn(x):
+        return 1 / (1 + np.exp(-x))
+
+    def d_score_fn(x):
+        s = 1 / (1 + np.exp(-x))
+        return s * (1 - s)
+
+    ica = FastICA(contrast_fn=contrast_fn, score_fn=score_fn, d_score_fn=d_score_fn)
+
+    assert isinstance(ica, IterativeMethodBase)
+
+
+def test_grad_fdica_inheritance() -> None:
+    def contrast_fn(y):
+        return 2 * np.abs(y)
+
+    def score_fn(y):
+        denominator = np.maximum(np.abs(y), 1e-10)
+        return y / denominator
+
+    fdica = GradFDICA(contrast_fn=contrast_fn, score_fn=score_fn)
+
+    assert isinstance(fdica, IterativeMethodBase)
+
+    fdica = GradLaplaceFDICA()
+
+    assert isinstance(fdica, IterativeMethodBase)
+
+
+def test_natural_grad_fdica_inheritance() -> None:
+    def contrast_fn(y):
+        return 2 * np.abs(y)
+
+    def score_fn(y):
+        denominator = np.maximum(np.abs(y), 1e-10)
+        return y / denominator
+
+    fdica = NaturalGradFDICA(contrast_fn=contrast_fn, score_fn=score_fn)
+
+    assert isinstance(fdica, IterativeMethodBase)
+
+    fdica = NaturalGradLaplaceFDICA()
+
+    assert isinstance(fdica, IterativeMethodBase)
+
+
+def test_aux_fdica_inheritance() -> None:
+    def contrast_fn(y):
+        return 2 * np.abs(y)
+
+    def d_contrast_fn(y):
+        return 2 * np.ones_like(y)
+
+    fdica = AuxFDICA(
+        contrast_fn=contrast_fn,
+        d_contrast_fn=d_contrast_fn,
+    )
+
+    assert isinstance(fdica, IterativeMethodBase)
+
+    fdica = AuxLaplaceFDICA()
+
+    assert isinstance(fdica, IterativeMethodBase)
+
+
+def test_grad_iva_inheritance() -> None:
+    def contrast_fn(y: np.ndarray) -> np.ndarray:
+        r"""Contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_bins, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_frames).
+        """
+        return 2 * np.linalg.norm(y, axis=1)
+
+    def score_fn(y) -> np.ndarray:
+        r"""Score function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_bins, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_bins, n_frames).
+        """
+        norm = np.linalg.norm(y, axis=1, keepdims=True)
+        norm = np.maximum(norm, 1e-10)
+        return y / norm
+
+    iva = GradIVA(contrast_fn=contrast_fn, score_fn=score_fn)
+
+    assert isinstance(iva, IterativeMethodBase)
+
+    iva = GradLaplaceIVA()
+
+    assert isinstance(iva, IterativeMethodBase)
+
+    iva = GradGaussIVA()
+
+    assert isinstance(iva, IterativeMethodBase)
+
+
+def test_natural_grad_iva_inheritance() -> None:
+    def contrast_fn(y: np.ndarray) -> np.ndarray:
+        r"""Contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_bins, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_frames).
+        """
+        return 2 * np.linalg.norm(y, axis=1)
+
+    def score_fn(y):
+        r"""Score function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_bins, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_bins, n_frames).
+        """
+        norm = np.linalg.norm(y, axis=1, keepdims=True)
+        norm = np.maximum(norm, 1e-10)
+        return y / norm
+
+    iva = NaturalGradIVA(contrast_fn=contrast_fn, score_fn=score_fn)
+
+    assert isinstance(iva, IterativeMethodBase)
+
+    iva = NaturalGradLaplaceIVA()
+
+    assert isinstance(iva, IterativeMethodBase)
+
+    iva = NaturalGradGaussIVA()
+
+    assert isinstance(iva, IterativeMethodBase)
+
+
+def test_fast_iva_inheritance() -> None:
+    def contrast_fn(y: np.ndarray) -> np.ndarray:
+        r"""Contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_bins, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_frames).
+        """
+        return 2 * np.linalg.norm(y, axis=1)
+
+    def d_contrast_fn(y) -> np.ndarray:
+        r"""Derivative of contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_frames).
+        """
+        return 2 * np.ones_like(y)
+
+    def dd_contrast_fn(y) -> np.ndarray:
+        r"""Second order derivative of contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_frames).
+        """
+        return 2 * np.zeros_like(y)
+
+    iva = FastIVA(
+        contrast_fn=contrast_fn,
+        d_contrast_fn=d_contrast_fn,
+        dd_contrast_fn=dd_contrast_fn,
+    )
+
+    assert isinstance(iva, IterativeMethodBase)
+
+
+def test_faster_iva_inheritance() -> None:
+    def contrast_fn(y: np.ndarray) -> np.ndarray:
+        r"""Contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_bins, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_frames).
+        """
+        return 2 * np.linalg.norm(y, axis=1)
+
+    def d_contrast_fn(y) -> np.ndarray:
+        r"""Derivative of contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_frames).
+        """
+        return 2 * np.ones_like(y)
+
+    iva = FasterIVA(contrast_fn=contrast_fn, d_contrast_fn=d_contrast_fn)
+
+    assert isinstance(iva, IterativeMethodBase)
+
+
+def test_aux_iva_inheritance() -> None:
+    def contrast_fn(y: np.ndarray) -> np.ndarray:
+        r"""Contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_bins, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_frames).
+        """
+        return 2 * np.linalg.norm(y, axis=1)
+
+    def d_contrast_fn(y) -> np.ndarray:
+        r"""Derivative of contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_frames).
+
+        Returns:
+            np.ndarray:
+                The shape is (n_sources, n_frames).
+        """
+        return 2 * np.ones_like(y)
+
+    iva = AuxIVA(
+        contrast_fn=contrast_fn,
+        d_contrast_fn=d_contrast_fn,
+    )
+
+    assert isinstance(iva, IterativeMethodBase)
+
+    iva = AuxLaplaceIVA()
+
+    assert isinstance(iva, IterativeMethodBase)
+
+    iva = AuxGaussIVA()
+
+    assert isinstance(iva, IterativeMethodBase)
+
+
+def test_pds_iva_inheritance() -> None:
+    iva = PDSIVA(
+        contrast_fn=None,
+        prox_penalty=None,
+    )
+
+    assert isinstance(iva, IterativeMethodBase)
+
+
+def test_ilrma_inheritance() -> None:
+    n_basis = 2
+
+    ilrma = GaussILRMA(n_basis=n_basis)
+
+    assert isinstance(ilrma, IterativeMethodBase)
+
+    ilrma = TILRMA(n_basis=n_basis, dof=1000)
+
+    assert isinstance(ilrma, IterativeMethodBase)
+
+    ilrma = GGDILRMA(n_basis=n_basis, beta=1.95)
+
+    assert isinstance(ilrma, IterativeMethodBase)
+
+
+def test_ipsdta_inheritance() -> None:
+    n_basis = 2
+    n_blocks = 2
+
+    ipsdta = GaussIPSDTA(n_basis=n_basis, n_blocks=n_blocks)
+
+    assert isinstance(ipsdta, IterativeMethodBase)
+
+    ipsdta = TIPSDTA(n_basis=n_basis, n_blocks=n_blocks, dof=1000)
+
+    assert isinstance(ipsdta, IterativeMethodBase)
+
+
+def test_mnmf_inheritance() -> None:
+    n_basis = 2
+
+    mnmf = GaussMNMF(n_basis=n_basis)
+
+    assert isinstance(mnmf, IterativeMethodBase)
+
+    mnmf = FastGaussMNMF(n_basis=n_basis)
+
+    assert isinstance(mnmf, IterativeMethodBase)
+
+
+def test_pdsbss_inheritance() -> None:
+    def contrast_fn(y: np.ndarray) -> np.ndarray:
+        r"""Contrast function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_bins, n_frames).
+
+        Returns:
+            np.ndarray of the shape is (n_sources, n_frames).
+        """
+        return 2 * np.linalg.norm(y, axis=1)
+
+    def penalty_fn(y: np.ndarray) -> float:
+        loss = contrast_fn(y)
+        loss = np.sum(loss.mean(axis=-1))
+        return loss
+
+    def prox_penalty(y: np.ndarray, step_size: float = 1) -> np.ndarray:
+        r"""Proximal operator of penalty function.
+
+        Args:
+            y (np.ndarray):
+                The shape is (n_sources, n_bins, n_frames).
+            step_size (float):
+                Step size. Default: 1.
+
+        Returns:
+            np.ndarray of the shape is (n_sources, n_bins, n_frames).
+        """
+        norm = np.linalg.norm(y, axis=1, keepdims=True)
+        return y * np.maximum(1 - step_size / norm, 0)
+
+    pdsbss = PDSBSS(penalty_fn=penalty_fn, prox_penalty=prox_penalty)
+
+    assert isinstance(pdsbss, IterativeMethodBase)
+
+
+def test_cacgmm_inheritance() -> None:
+    cacgmm = CACGMM()
+
+    assert isinstance(cacgmm, IterativeMethodBase)

--- a/tests/package/bss/test_pdsbss.py
+++ b/tests/package/bss/test_pdsbss.py
@@ -61,31 +61,7 @@ def prox_penalty(y: np.ndarray, step_size: float = 1) -> np.ndarray:
 
 
 def test_pds_base():
-    class DummyPDSBSS(PDSBSSBase):
-        pass
-
-    np.random.seed(111)
-
-    waveform_src_img, _ = download_sample_speech_data(
-        sisec2010_root="./tests/.data/SiSEC2010",
-        mird_root="./tests/.data/MIRD",
-        n_sources=2,
-        sisec2010_tag="dev1_female3",
-        max_duration=max_duration,
-        conv=True,
-    )
-    waveform_mix = np.sum(waveform_src_img, axis=1)  # (n_channels, n_samples)
-
-    _, _, spectrogram_mix = ss.stft(
-        waveform_mix, window="hann", nperseg=n_fft, noverlap=n_fft - hop_length
-    )
-
-    pdsbss = DummyPDSBSS(penalty_fn=penalty_fn, prox_penalty=prox_penalty)
-
-    with pytest.raises(NotImplementedError) as e:
-        _ = pdsbss(spectrogram_mix, n_iter=n_iter)
-
-    assert str(e.value) == "Implement '__call__' method."
+    pdsbss = PDSBSSBase(penalty_fn=penalty_fn, prox_penalty=prox_penalty)
 
     print(pdsbss)
 


### PR DESCRIPTION
## Summary
So far, `PDSBSSBase` has not inherited `IterativeMethodBase`. So we couldn't apply `isinstance` to this class.
By this PR, we can use `isinstance` by making `PDSBSSBase` inherit `IterativeMethodBase`.

close #261

<!--

## TODO
Describe what to do next.

-->