### PR TITLE
Fix timing of uploading package

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -69,5 +69,5 @@ jobs:
       id-token: write
     secrets:
       TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-    if: github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/upload_package.yaml

--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -69,5 +69,5 @@ jobs:
       id-token: write
     secrets:
       TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
-    if: github.event_name == "push"
+    if: github.event_name == 'push'
     uses: ./.github/workflows/upload_package.yaml

--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -39,6 +39,7 @@ jobs:
         run: |
           pytest -vvv -n 16 --cov=./ssspy --cov-report=xml tests/package/
       - name: Upload coverage to codecov
+        if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true

--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -69,4 +69,5 @@ jobs:
       id-token: write
     secrets:
       TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    if: github.event_name == "push"
     uses: ./.github/workflows/upload_package.yaml


### PR DESCRIPTION
## Summary
This PR fixes the timing of uploading the package.
So far, the uploading workflow is triggered when PR and push are performed. We can upload the identical package only once.