### PR TITLE
Add `needs` to upload_package job in GHA.

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -69,6 +69,9 @@ jobs:
         run: |
           python -m black --config pyproject.toml --check ssspy tests
   upload_package:
+    needs:
+      - build
+      - lint
     permissions:
       id-token: write
     secrets:


### PR DESCRIPTION
## Summary
This PR fixes workflow to skip a redundant job.